### PR TITLE
Fix documentation build by lowering jinja2 version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: absolufy-imports
         files: ^reciprocalspaceship/
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ docs_require = [
     "sphinx",
     "sphinx_rtd_theme",
     "nbsphinx",
+    "jinja2<3.1.0",
     "sphinx-panels",
     "sphinxcontrib-autoprogram",
     "autodocsumm",


### PR DESCRIPTION
This is a quick fix to the documentation build. There is a current issue with sphinx due to a newer version of Jinja2 (https://github.com/readthedocs/readthedocs.org/issues/9037#issuecomment-1077818554).

After this fix, I'll look into making a more future-proof documentation build -- might require updating to using a more recent Python version when building documentation.