### PR TITLE
Upgrade sphinx version by removing sphinx_panels dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ extensions = [
     "sphinx_rtd_theme",
     "nbsphinx",
     "sphinx.ext.linkcode",
-    "sphinx_panels",
+    "sphinx_design",
     "sphinxcontrib.autoprogram",
     "autodocsumm",
 ]
@@ -145,6 +145,7 @@ html_favicon = "img/rs-favicon_32x32.png"
 html_logo = "img/rs.png"
 
 # -- Resolve links to source code --------------------------------------------
+
 
 # based on pandas/doc/source/conf.py
 def linkcode_resolve(domain, info):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,30 +19,40 @@ Features of this library include:
   symmetry operations.
 - Support for reading and writing MTZ reflection files.
 
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-4 col-md-4 col-sm-6 col-xs-12 p-2
+.. grid:: 3
 
-    The user guide provides information about installing and using ``reciprocalspaceship``
-    +++
-    .. link-button:: userguide/index
-       :type: ref
-       :text: User Guide
-       :classes: btn-outline-primary btn-block stretched-link
-    ---
-    The API reference provides detailed information about the Python API for the library
-    +++
-    .. link-button:: api/index
-        :type: ref
-        :text: API Reference
-        :classes: btn-outline-primary btn-block stretched-link
-    ---
-    The developer's guide is a resource for those looking to contribute to this project
-    +++
-    .. link-button:: developers/index
-        :type: ref
-        :text: Developer Guide
-        :classes: btn-outline-primary btn-block stretched-link
+    .. grid-item-card:: User Guide
+
+       The user guide provides information about installing and using ``reciprocalspaceship``
+
+       .. button-ref:: userguide/index
+           :color: primary
+	   :shadow:
+           :expand:
+
+           User Guide
+
+    .. grid-item-card:: API Reference
+
+        The API reference provides details about the Python API for the library
+
+        .. button-ref:: api/index
+           :color: primary
+	   :shadow:
+           :expand:
+
+           API Reference
+
+    .. grid-item-card:: Developer's Guide
+
+        The developer's guide is a resource for those looking to contribute to this project
+
+	.. button-ref:: developers/index
+           :color: primary
+	   :shadow:
+           :expand:
+
+           Developer's Guide
 
 .. toctree::
    :maxdepth: 1

--- a/setup.py
+++ b/setup.py
@@ -45,8 +45,7 @@ docs_require = [
     "sphinx",
     "sphinx_rtd_theme",
     "nbsphinx",
-    "jinja2<3.1.0",
-    "sphinx-panels",
+    "sphinx-design",
     "sphinxcontrib-autoprogram",
     "autodocsumm",
 ]


### PR DESCRIPTION
The documentation used a deprecated sphinx extension called `sphinx_panels`. This update switches to the updated version called `sphinx_design`. This should make it so that a later version of sphinx can be used for building documentation, which resolves the jinja2 version issue from #202 and as a side effect also resolves the issue identified in #206.

This worked locally without the need for setting an explicit minimal sphinx version in `setup.py`, but it might behave differently in the CI. 