### PR TITLE
Fixes #194: Update rs.utils.in_asu() docstring to clarify behavior

### DIFF
--- a/reciprocalspaceship/utils/asu.py
+++ b/reciprocalspaceship/utils/asu.py
@@ -40,6 +40,12 @@ def in_asu(H, spacegroup):
     """
     Check to see if Miller indices are in the asymmetric unit of a space group.
 
+    Notes
+    -----
+    This function only returns True for the +ASU, and does not consider Miller
+    indices for Friedel pairs to be in the ASU. As such, anomalous data should
+    be provided in two-column anomalous format.
+
     Parameters
     ----------
     H : array


### PR DESCRIPTION
This PR addresses #194 to clarify that `rs.utils.in_asu()` does not accept +/- Friedel pairs -- only Miller indices in the +ASU will be labeled as True.