### PR TITLE
Add python 3.11 to build tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     # Skip CI if 'skip ci' is contained in latest commit message
     if: "!contains(github.event.head_commit.message, 'skip ci')"


### PR DESCRIPTION
Python 3.11 should be added to the build tests to stay on top of any issues that may arise.