### PR TITLE
clip I for Sigma calc

### DIFF
--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -95,6 +95,7 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     return mean, np.sqrt(variance), mean_F, np.sqrt(variance_F)
 
 
+
 def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     Use a gaussian kernel smoother to compute mean intensities as a function of miller index.
@@ -115,6 +116,7 @@ def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     H = np.array(H, dtype=np.float32)
     I = np.array(I, dtype=np.float32)
+    I = np.clip(I, a_min=0,a_max=1e20)
     bandwidth = np.float32(bandwidth) ** 2.0
     n = len(I)
 

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -255,7 +255,7 @@ def scale_merged_intensities(
         reciprocal space. Only affects output if mean_intensity_method is
         \"anisotropic\".
     clip_neg_Iobs : bool
-        Will set negative Iobs to 0 for the purpose of calculating Sigma. 
+        Will set negative Iobs to 0 for the purpose of calculating Sigma.
         Addresses rare cases where local average Iobs is negative.
         Default: False.
 


### PR DESCRIPTION
When using `scale_merged_intensities` to perform French-Wilson scaling in the `anisotropic` mode, the local Sigma is calculated by a local weighted average of observed intensities. As a consequence, Sigma can be negative. This leads to NaNs in the calculation of the logpdf used to calculate the posterior expected intensity. To remedy this, I propose clipping the observed intensities to be positive in (and only in) the calculation of Sigma in `mean_intensity_by_miller_index(I, H, bandwidth)`.