### PR TITLE
Support clipping Sigma to avoid negative values in French-Wilson method

### DIFF
--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -95,8 +95,12 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     return mean, np.sqrt(variance), mean_F, np.sqrt(variance_F)
 
 
+<<<<<<< HEAD
 
 def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Iobs):
+=======
+def mean_intensity_by_miller_index(I, H, bandwidth):
+>>>>>>> d25d7da19615acf5c6694af20766c9a7cbeb80b2
     """
     Use a gaussian kernel smoother to compute mean intensities as a function of miller index.
 
@@ -118,8 +122,12 @@ def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Iobs):
     """
     H = np.array(H, dtype=np.float32)
     I = np.array(I, dtype=np.float32)
+<<<<<<< HEAD
     if clip_neg_Iobs:
         I = np.clip(I, a_min=0,a_max=1e20)
+=======
+    I = np.clip(I, a_min=0, a_max=1e20)
+>>>>>>> d25d7da19615acf5c6694af20766c9a7cbeb80b2
     bandwidth = np.float32(bandwidth) ** 2.0
     n = len(I)
 

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -95,6 +95,7 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     return mean, np.sqrt(variance), mean_F, np.sqrt(variance_F)
 
 
+
 def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     Use a gaussian kernel smoother to compute mean intensities as a function of miller index.
@@ -115,6 +116,7 @@ def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     H = np.array(H, dtype=np.float32)
     I = np.array(I, dtype=np.float32)
+    I = np.clip(I, a_min=0,a_max=1e20)
     bandwidth = np.float32(bandwidth) ** 2.0
     n = len(I)
 

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -241,7 +241,7 @@ def scale_merged_intensities(
         parameter controls the distance that each reflection impacts in
         reciprocal space. Only affects output if mean_intensity_method is
         \"anisotropic\".
-    minimum_sigma : float 
+    minimum_sigma : float
         Minimum value imposed on Sigma (default: -np.inf, that is: no minimum).
 
 
@@ -285,15 +285,9 @@ def scale_merged_intensities(
     I, Sig = ds[intensity_key].to_numpy(), ds[sigma_key].to_numpy()
     if mean_intensity_method == "isotropic":
         dHKL = ds["dHKL"].to_numpy(dtype=np.float64)
-        Sigma = (
-            mean_intensity_by_resolution(I / multiplicity, dHKL, bins)
-        )
+        Sigma = mean_intensity_by_resolution(I / multiplicity, dHKL, bins)
     elif mean_intensity_method == "anisotropic":
-        Sigma = (
-            mean_intensity_by_miller_index(
-                I / multiplicity, ds.get_hkls(), bw
-            )
-        )
+        Sigma = mean_intensity_by_miller_index(I / multiplicity, ds.get_hkls(), bw)
     Sigma = np.clip(Sigma, a_min=minimum_sigma, a_max=np.inf)
     Sigma = Sigma * multiplicity
 

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -118,7 +118,7 @@ def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Iobs):
     H = np.array(H, dtype=np.float32)
     I = np.array(I, dtype=np.float32)
     if clip_neg_Iobs:
-        I = np.clip(I, a_min=0,a_max=1e20)
+        I = np.clip(I, a_min=0, a_max=1e20)
     bandwidth = np.float32(bandwidth) ** 2.0
     n = len(I)
 
@@ -246,7 +246,7 @@ def scale_merged_intensities(
         reciprocal space. Only affects output if mean_intensity_method is
         \"anisotropic\".
     clip_neg_Iobs : bool
-        Will set negative Iobs to 0 for the purpose of calculating Sigma. 
+        Will set negative Iobs to 0 for the purpose of calculating Sigma.
         Addresses rare cases where local average Iobs is negative.
         Default: False.
 
@@ -296,7 +296,9 @@ def scale_merged_intensities(
         )
     elif mean_intensity_method == "anisotropic":
         Sigma = (
-            mean_intensity_by_miller_index(I / multiplicity, ds.get_hkls(), bw, clip_neg_Iobs)
+            mean_intensity_by_miller_index(
+                I / multiplicity, ds.get_hkls(), bw, clip_neg_Iobs
+            )
             * multiplicity
         )
 

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -95,7 +95,7 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     return mean, np.sqrt(variance), mean_F, np.sqrt(variance_F)
 
 
-def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Sigma=False, eps=0.001):
+def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     Use a gaussian kernel smoother to compute mean intensities as a function of miller index.
 
@@ -107,9 +107,6 @@ def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Sigma=False, eps=0.
         Nx3 array of miller indices
     bandwidth : float(optional)
         Kernel bandwidth in miller units
-    clip_neg_Sigma : bool(optional, default False)
-        If true, clips Sigma to be at least 0.0001 before calculating Sigma
-    eps (float) : small positive number to clip Sigma to (if clip_neg_Sigma=True). Default=0.001.
 
     Returns
     -------
@@ -125,9 +122,6 @@ def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Sigma=False, eps=0.
     for i in range(n):
         K = np.exp(-0.5 * ((H - H[i]) * (H - H[i])).sum(1) / bandwidth)
         S[i] = (I * K).sum() / K.sum()
-
-    if clip_neg_Sigma:
-        S = np.clip(S, a_min=eps, a_max=1e20)
 
     return S
 
@@ -191,8 +185,7 @@ def scale_merged_intensities(
     mean_intensity_method="isotropic",
     bins=100,
     bw=2.0,
-    clip_neg_Sigma=False,
-    eps=0.001,
+    minimum_sigma=-np.inf,
 ):
     """
     Scales merged intensities using Bayesian statistics in order to
@@ -248,11 +241,8 @@ def scale_merged_intensities(
         parameter controls the distance that each reflection impacts in
         reciprocal space. Only affects output if mean_intensity_method is
         \"anisotropic\".
-    clip_neg_Sigma : bool
-        Will set negative Sigma to 0 for the purpose of calculating Sigma.
-        Addresses rare cases where local average Iobs is negative.
-        Default: False. *Used by valdo*.
-    eps : float Floor imposed on Sigma if clipping.
+    minimum_sigma : float 
+        Minimum value imposed on Sigma (default: -np.inf, that is: no minimum).
 
 
     Returns
@@ -296,15 +286,16 @@ def scale_merged_intensities(
     if mean_intensity_method == "isotropic":
         dHKL = ds["dHKL"].to_numpy(dtype=np.float64)
         Sigma = (
-            mean_intensity_by_resolution(I / multiplicity, dHKL, bins) * multiplicity
+            mean_intensity_by_resolution(I / multiplicity, dHKL, bins)
         )
     elif mean_intensity_method == "anisotropic":
         Sigma = (
             mean_intensity_by_miller_index(
-                I / multiplicity, ds.get_hkls(), bw, clip_neg_Sigma, eps
+                I / multiplicity, ds.get_hkls(), bw
             )
-            * multiplicity
         )
+    Sigma = np.clip(Sigma, a_min=minimum_sigma, a_max=np.inf)
+    Sigma = Sigma * multiplicity
 
     # Initialize outputs
     ds[outputI] = 0.0

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -40,7 +40,6 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     Iobs = np.array(Iobs, dtype=np.float64)
     SigIobs = np.array(SigIobs, dtype=np.float64)
     Sigma = np.array(Sigma, dtype=np.float64)
-    print(np.amin(Sigma))
 
     # Integration window based on the normal, likelihood distribution
     window_size = 20.0  # In standard devs

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -95,12 +95,7 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     return mean, np.sqrt(variance), mean_F, np.sqrt(variance_F)
 
 
-<<<<<<< HEAD
-
 def mean_intensity_by_miller_index(I, H, bandwidth, clip_neg_Iobs):
-=======
-def mean_intensity_by_miller_index(I, H, bandwidth):
->>>>>>> d25d7da19615acf5c6694af20766c9a7cbeb80b2
     """
     Use a gaussian kernel smoother to compute mean intensities as a function of miller index.
 
@@ -122,12 +117,8 @@ def mean_intensity_by_miller_index(I, H, bandwidth):
     """
     H = np.array(H, dtype=np.float32)
     I = np.array(I, dtype=np.float32)
-<<<<<<< HEAD
     if clip_neg_Iobs:
         I = np.clip(I, a_min=0,a_max=1e20)
-=======
-    I = np.clip(I, a_min=0, a_max=1e20)
->>>>>>> d25d7da19615acf5c6694af20766c9a7cbeb80b2
     bandwidth = np.float32(bandwidth) ** 2.0
     n = len(I)
 


### PR DESCRIPTION
I added a flag permitting clipping of Iobs to positive values for the purpose of calculating Sigma during anisotropic FW calculation. The option is off by default.