### PR TITLE
Use einsum in weighted_pearsonr

### DIFF
--- a/reciprocalspaceship/utils/stats.py
+++ b/reciprocalspaceship/utils/stats.py
@@ -107,15 +107,15 @@ def weighted_pearsonr(x, y, w):
     """
     z = np.reciprocal(w.sum(-1))
 
-    mx = z * (w * x).sum(-1)
-    my = z * (w * y).sum(-1)
+    mx = z * np.einsum("...a,...a->...", w, x)
+    my = z * np.einsum("...a,...a->...", w, y)
 
     dx = x - np.expand_dims(mx, axis=-1)
     dy = y - np.expand_dims(my, axis=-1)
 
-    cxy = z * (w * dx * dy).sum(-1)
-    cx = z * (w * dx * dx).sum(-1)
-    cy = z * (w * dy * dy).sum(-1)
+    cxy = z * np.einsum("...a,...a,...a->...", w, dx, dy)
+    cx =  z * np.einsum("...a,...a,...a->...", w, dx, dx)
+    cy =  z * np.einsum("...a,...a,...a->...", w, dy, dy)
 
     r = cxy / np.sqrt(cx * cy)
     return r

--- a/reciprocalspaceship/utils/stats.py
+++ b/reciprocalspaceship/utils/stats.py
@@ -114,8 +114,8 @@ def weighted_pearsonr(x, y, w):
     dy = y - np.expand_dims(my, axis=-1)
 
     cxy = z * np.einsum("...a,...a,...a->...", w, dx, dy)
-    cx =  z * np.einsum("...a,...a,...a->...", w, dx, dx)
-    cy =  z * np.einsum("...a,...a,...a->...", w, dy, dy)
+    cx = z * np.einsum("...a,...a,...a->...", w, dx, dx)
+    cy = z * np.einsum("...a,...a,...a->...", w, dy, dy)
 
     r = cxy / np.sqrt(cx * cy)
     return r


### PR DESCRIPTION
This PR just optimizes `rs.utils.weighted_pearsonr` by replacing sequential multiplication and summation with `np.einsum`. This allows numpy to calculate r faster and with less memory. 