### PR TITLE
support **kwargs in gemmification decoratored fn

### DIFF
--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -100,7 +100,7 @@ def spacegroupify(func=None, *sg_args):
             for arg in sg_args:
                 if arg in bargs.arguments:
                     bargs.arguments[arg] = _convert_spacegroup(bargs.arguments[arg])
-            return f(**bargs.arguments)
+            return f(*bargs.args, **bargs.kwargs)
 
         return wrapped
 
@@ -155,7 +155,7 @@ def cellify(func=None, *cell_args):
             for arg in cell_args:
                 if arg in bargs.arguments:
                     bargs.arguments[arg] = _convert_unitcell(bargs.arguments[arg])
-            return f(**bargs.arguments)
+            return f(*bargs.args, **bargs.kwargs)
 
         return wrapped
 


### PR DESCRIPTION
This PR modifies the `@spacegroupify` and `@cellify` decorators so as to support decorating functions which take arbitrary keyword arguments (`**kwargs`). Specifically, it alters the usage of the `BoundArguments` instance in the decorated function call. 

`f(**bargs.arguments)` becomes `f(*bargs.args, **bargs.kwargs)`