### PR TITLE
set maximum numpy version to <2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
     install_requires=[
         "gemmi>=0.5.5, <=0.6.6",
         "pandas>=2.2.2, <=2.2.2",
-        "numpy",
+        "numpy<2.0",
         "scipy",
         "ipython",
     ],


### PR DESCRIPTION
`numpy` version 2.0 is breaking a bunch of tests. We should set a maximum version number until we can diagnose the issues. 

To replicate:
```bash
conda create -yn rs python=3.11
conda activate rs
git clone https://github.com/rs-station/reciprocalspaceship
cd reciprocalspaceship
pip install -e . 
python setup.py test
```