### PR TITLE
enable numpy 2.0 support

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1234,6 +1234,7 @@ class DataSet(pd.DataFrame):
         # Compute new HKLs and phase shifts
         hkls = dataset.get_hkls()
         compressed_hkls, inverse = np.unique(hkls, axis=0, return_inverse=True)
+        inverse = inverse.squeeze(-1)
         asu_hkls, isym, phi_coeff, phi_shift = hkl_to_asu(
             compressed_hkls, dataset.spacegroup, return_phase_shifts=True
         )

--- a/reciprocalspaceship/dtypes/floating.py
+++ b/reciprocalspaceship/dtypes/floating.py
@@ -45,6 +45,7 @@ except:
 
 from pandas import Float32Dtype, Float64Dtype
 from pandas.core.arrays import ExtensionArray
+from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_float,
@@ -54,7 +55,6 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 from pandas.core.tools.numeric import to_numeric
 

--- a/reciprocalspaceship/dtypes/floating.py
+++ b/reciprocalspaceship/dtypes/floating.py
@@ -54,6 +54,7 @@ from pandas.core.dtypes.common import (
     is_object_dtype,
     pandas_dtype,
 )
+from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 from pandas.core.tools.numeric import to_numeric
 
@@ -80,7 +81,7 @@ class MTZFloat32Dtype(MTZDtype):
             return self
         if not all(isinstance(t, MTZFloat32Dtype) for t in dtypes):
             return None
-        np_dtype = np.find_common_type(
+        np_dtype = np_find_common_type(
             # error: Item "ExtensionDtype" of "Union[Any, ExtensionDtype]" has no
             # attribute "numpy_dtype"
             [t.numpy_dtype for t in dtypes],  # type: ignore[union-attr]
@@ -136,7 +137,11 @@ def coerce_to_array(
             mask = mask.copy()
         return values, mask
 
-    values = np.array(values, copy=copy)
+    if copy:
+        values = np.array(values, copy=copy)
+    else:
+        values = np.asarray(values)
+
     if is_object_dtype(values.dtype):
         inferred_type = lib.infer_dtype(values, skipna=True)
         if inferred_type == "empty":

--- a/reciprocalspaceship/dtypes/integer.py
+++ b/reciprocalspaceship/dtypes/integer.py
@@ -47,6 +47,7 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
     pandas_dtype,
 )
+from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
 
@@ -88,7 +89,7 @@ class MTZInt32Dtype(MTZDtype):
             for t in dtypes
         ):
             return None
-        np_dtype = np.find_common_type(
+        np_dtype = np_find_common_type(
             # error: List comprehension has incompatible type List[Union[Any,
             # dtype, ExtensionDtype]]; expected List[Union[dtype, None, type,
             # _SupportsDtype, str, Tuple[Any, Union[int, Sequence[int]]],
@@ -175,7 +176,11 @@ def coerce_to_array(
             mask = mask.copy()
         return values, mask
 
-    values = np.array(values, copy=copy)
+    if copy:
+        values = np.array(values, copy=copy)
+    else:
+        values = np.asarray(values)
+
     inferred_type = None
     if is_object_dtype(values.dtype) or is_string_dtype(values.dtype):
         inferred_type = lib.infer_dtype(values, skipna=True)

--- a/reciprocalspaceship/dtypes/integer.py
+++ b/reciprocalspaceship/dtypes/integer.py
@@ -39,6 +39,7 @@ from pandas._libs import missing as libmissing
 from pandas._typing import ArrayLike, Dtype, DtypeObj
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.base import ExtensionDtype, register_extension_dtype
+from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.dtypes.common import (
     is_bool_dtype,
     is_float_dtype,
@@ -47,7 +48,6 @@ from pandas.core.dtypes.common import (
     is_string_dtype,
     pandas_dtype,
 )
-from pandas.core.dtypes.cast import np_find_common_type
 from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
 

--- a/reciprocalspaceship/utils/cell.py
+++ b/reciprocalspaceship/utils/cell.py
@@ -24,6 +24,7 @@ def compute_dHKL(H, cell):
     # Compress the hkls so we don't do redudant computation
     H = np.array(H, dtype=np.float32)
     hkls, inverse = np.unique(H, axis=0, return_inverse=True)
+    inverse = inverse.squeeze(-1)
     F = np.array(cell.fractionalization_matrix.tolist()).astype(np.float64)
     dhkls = np.reciprocal(np.linalg.norm((hkls @ F), 2, 1)).astype(np.float32)
     return dhkls[inverse]

--- a/reciprocalspaceship/utils/stats.py
+++ b/reciprocalspaceship/utils/stats.py
@@ -36,7 +36,6 @@ def compute_redundancy(
     counts : np.array (int32)
         A length n array of counts for each miller index in hunique.
     """
-    hasu = hobs.copy()
     hobs = hobs[~rs.utils.is_absent(hobs, spacegroup)]
     dhkl = rs.utils.compute_dHKL(hobs, cell)
     if dmin is None:

--- a/reciprocalspaceship/utils/stats.py
+++ b/reciprocalspaceship/utils/stats.py
@@ -36,13 +36,12 @@ def compute_redundancy(
     counts : np.array (int32)
         A length n array of counts for each miller index in hunique.
     """
+    hasu = hobs.copy()
     hobs = hobs[~rs.utils.is_absent(hobs, spacegroup)]
     dhkl = rs.utils.compute_dHKL(hobs, cell)
     if dmin is None:
         dmin = dhkl.min()
     hobs = hobs[dhkl >= dmin]
-    decimals = 5.0  # Round after this many decimals
-    dmin = np.floor(dmin * 10**decimals) * 10**-decimals
     hobs, isym = rs.utils.hkl_to_asu(hobs, spacegroup)
     if anomalous:
         fminus = isym % 2 == 0

--- a/reciprocalspaceship/utils/structurefactors.py
+++ b/reciprocalspaceship/utils/structurefactors.py
@@ -104,6 +104,7 @@ def is_centric(H, spacegroup):
     """
     group_ops = spacegroup.operations()
     hkl, inverse = np.unique(H, axis=0, return_inverse=True)
+    inverse = inverse.squeeze(-1)
     centric = group_ops.centric_flag_array(hkl)
     return centric[inverse]
 

--- a/tests/algorithms/conftest.py
+++ b/tests/algorithms/conftest.py
@@ -12,10 +12,10 @@ def data_hewl_all(data_merged, request):
     if request.param == "hewl":
         return data_merged
     elif request.param == "hewl_IMEAN_NaN":
-        data_merged.loc[(0, 0, 4), "IMEAN"] = np.NaN
+        data_merged.loc[(0, 0, 4), "IMEAN"] = np.nan
         return data_merged
     elif request.param == "hewl_I(+)_NaN":
-        data_merged.loc[(0, 0, 4), "I(+)"] = np.NaN
+        data_merged.loc[(0, 0, 4), "I(+)"] = np.nan
         return data_merged
 
 


### PR DESCRIPTION
This PR enables `rs` to run on `numpy` version 2.0 which is also supported by the latest `pandas` release. The major changes required were
 - Squeeze extra dim from inverse returned by `np.unique`
 - `np.find_common_type` was removed in version 2.0, but pandas provides an equivalent method, `from pandas.core.dtypes.cast import np_find_common_type`
 - Remove `np.NaN` which is now exclusively `np.nan`
 - `np.array` no longer supports `np.array(list, copy=False`. So I added some control flow which relies on `np.asarray`. 