### PR TITLE
Is numeric na

### DIFF
--- a/reciprocalspaceship/dtypes/floating.py
+++ b/reciprocalspaceship/dtypes/floating.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 
 import numpy as np
 from pandas._libs import lib
-from pandas._libs import missing as libmissing
 from pandas._typing import ArrayLike, DtypeObj
 from pandas.util._decorators import cache_readonly
 
@@ -59,7 +58,7 @@ from pandas.core.dtypes.dtypes import ExtensionDtype, register_extension_dtype
 from pandas.core.tools.numeric import to_numeric
 
 from reciprocalspaceship.dtypes.base import MTZDtype
-from reciprocalspaceship.dtypes.internals import NumericArray
+from reciprocalspaceship.dtypes.internals import NumericArray, is_numeric_na
 
 
 class MTZFloat32Dtype(MTZDtype):
@@ -165,7 +164,7 @@ def coerce_to_array(
         raise TypeError("values must be a 1D list-like")
 
     if mask is None:
-        mask = libmissing.is_numeric_na(values)
+        mask = is_numeric_na(values)
 
     else:
         assert len(mask) == len(values)

--- a/reciprocalspaceship/dtypes/integer.py
+++ b/reciprocalspaceship/dtypes/integer.py
@@ -51,7 +51,11 @@ from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
 
 from reciprocalspaceship.dtypes.base import MTZDtype
-from reciprocalspaceship.dtypes.internals import BaseMaskedDtype, NumericArray, is_numeric_na
+from reciprocalspaceship.dtypes.internals import (
+    BaseMaskedDtype,
+    NumericArray,
+    is_numeric_na,
+)
 
 
 class MTZInt32Dtype(MTZDtype):

--- a/reciprocalspaceship/dtypes/integer.py
+++ b/reciprocalspaceship/dtypes/integer.py
@@ -35,7 +35,6 @@ from __future__ import annotations
 import numpy as np
 from pandas import Float32Dtype, Int32Dtype, Int64Dtype
 from pandas._libs import lib
-from pandas._libs import missing as libmissing
 from pandas._typing import ArrayLike, Dtype, DtypeObj
 from pandas.core.arrays import ExtensionArray
 from pandas.core.dtypes.base import ExtensionDtype, register_extension_dtype
@@ -52,7 +51,7 @@ from pandas.core.tools.numeric import to_numeric
 from pandas.util._decorators import cache_readonly
 
 from reciprocalspaceship.dtypes.base import MTZDtype
-from reciprocalspaceship.dtypes.internals import BaseMaskedDtype, NumericArray
+from reciprocalspaceship.dtypes.internals import BaseMaskedDtype, NumericArray, is_numeric_na
 
 
 class MTZInt32Dtype(MTZDtype):
@@ -207,7 +206,7 @@ def coerce_to_array(
         raise TypeError("values must be a 1D list-like")
 
     if mask is None:
-        mask = libmissing.is_numeric_na(values)
+        mask = is_numeric_na(values)
     else:
         assert len(mask) == len(values)
 

--- a/reciprocalspaceship/dtypes/internals.py
+++ b/reciprocalspaceship/dtypes/internals.py
@@ -34,8 +34,8 @@ from __future__ import annotations
 
 import numbers
 import warnings
-from typing import Any, Sequence
 from functools import wraps
+from typing import Any, Sequence
 
 import numpy as np
 from pandas._libs import lib
@@ -1355,6 +1355,7 @@ class NumericArray(BaseMaskedArray):
         nv.validate_round(args, kwargs)
         values = np.round(self._data, decimals=decimals, **kwargs)
         return type(self)(values, self._mask.copy())
+
 
 @wraps(libmissing.is_numeric_na)
 def is_numeric_na(values):

--- a/reciprocalspaceship/dtypes/internals.py
+++ b/reciprocalspaceship/dtypes/internals.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import numbers
 import warnings
 from typing import Any, Sequence
+from functools import wraps
 
 import numpy as np
 from pandas._libs import lib
@@ -1354,3 +1355,10 @@ class NumericArray(BaseMaskedArray):
         nv.validate_round(args, kwargs)
         values = np.round(self._data, decimals=decimals, **kwargs)
         return type(self)(values, self._mask.copy())
+
+@wraps(libmissing.is_numeric_na)
+def is_numeric_na(values):
+    allowed_dtypes = ("float32", "int32")
+    if isinstance(values, np.ndarray) and values.dtype in allowed_dtypes:
+        return np.isnan(values)
+    return libmissing.is_numeric_na(values)


### PR DESCRIPTION
This PR speeds up dataset creation for large arrays. In working on a new stream file parser, I realized that converting numpy float32 and int32  to MTZDtypes  could be very time-consuming for large arrays. After some digging, I found out the culprit was a cython function provided by pandas, `pandas._libs.missing.is_numeric_na` which makes a mask for missing values in `rs` 
 - ['floating.py`](https://github.com/rs-station/reciprocalspaceship/blob/2ef8ae44b3d3d456cf6ba2efdcd751c65c04330c/reciprocalspaceship/dtypes/floating.py#L163)
 - ['integer.py'](https://github.com/rs-station/reciprocalspaceship/blob/2ef8ae44b3d3d456cf6ba2efdcd751c65c04330c/reciprocalspaceship/dtypes/integer.py#L205)

In the case that the input is an int32 or float32 numpy array, this is wholly unnecessary, and it is much faster to use `np.isnan` to accomplish the same task. This PR just wraps is_numeric_na and adds some control flow to accomplish that. It falls back to the Cython version whenever the input is not an int32 or float32 ndarray. This is a very conservative choice, and more circumstances could probably be included in the control flow down the line. 