### PR TITLE
Add support for range indexed data in `DataSet.write_mtz()` and `DataSet.to_gemmi()`

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -406,6 +406,7 @@ class DataSet(pd.DataFrame):
         """
         return cls(gemmiMtz)
 
+    @range_indexed
     def to_gemmi(
         self,
         skip_problem_mtztypes=False,

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -575,6 +575,7 @@ class DataSet(pd.DataFrame):
         result = super().join(*args, **kwargs)
         return result.__finalize__(self)
 
+    @range_indexed
     def write_mtz(
         self,
         mtzfile,

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -3,6 +3,7 @@ from inspect import signature
 
 import gemmi
 import numpy as np
+import reciprocalspaceship as rs
 
 
 def inplace(f):
@@ -49,6 +50,9 @@ def range_indexed(f):
         if result is None:
             ds._index_from_names(names, inplace=True)
             return
+        if not isinstance(result, rs.DataSet):
+            ds._index_from_names(names, inplace=True)
+            return result
         result = result._index_from_names(names, inplace=True)
         ds = ds._index_from_names(names, inplace=True)
         return result.__finalize__(ds)

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -47,14 +47,12 @@ def range_indexed(f):
         names = ds.index.names
         ds = ds._index_from_names([None], inplace=True)
         result = f(ds, *args, **kwargs)
+        ds = ds._index_from_names(names, inplace=True)
         if result is None:
-            ds._index_from_names(names, inplace=True)
             return
         if not isinstance(result, rs.DataSet):
-            ds._index_from_names(names, inplace=True)
             return result
         result = result._index_from_names(names, inplace=True)
-        ds = ds._index_from_names(names, inplace=True)
         return result.__finalize__(ds)
 
     return wrapped

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -46,6 +46,9 @@ def range_indexed(f):
         names = ds.index.names
         ds = ds._index_from_names([None], inplace=True)
         result = f(ds, *args, **kwargs)
+        if result is None:
+            ds._index_from_names(names, inplace=True)
+            return
         result = result._index_from_names(names, inplace=True)
         ds = ds._index_from_names(names, inplace=True)
         return result.__finalize__(ds)

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -3,6 +3,7 @@ from inspect import signature
 
 import gemmi
 import numpy as np
+
 import reciprocalspaceship as rs
 
 

--- a/reciprocalspaceship/decorators.py
+++ b/reciprocalspaceship/decorators.py
@@ -49,12 +49,10 @@ def range_indexed(f):
         ds = ds._index_from_names([None], inplace=True)
         result = f(ds, *args, **kwargs)
         ds = ds._index_from_names(names, inplace=True)
-        if result is None:
-            return
-        if not isinstance(result, rs.DataSet):
-            return result
-        result = result._index_from_names(names, inplace=True)
-        return result.__finalize__(ds)
+        if isinstance(result, rs.DataSet):
+            result = result._index_from_names(names, inplace=True)
+            result = result.__finalize__(ds)
+        return result
 
     return wrapped
 

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -142,7 +142,6 @@ def to_gemmi(
             columns.append(c)
         # Special case for CENTRIC and PARTIAL flags
         elif cseries.dtype.name == "bool" and c in ["CENTRIC", "PARTIAL"]:
-            dataset[c] = dataset[c].astype("MTZInt")
             mtz.add_column(label=c, type="I")
             columns.append(c)
         elif skip_problem_mtztypes:

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -133,16 +133,16 @@ def to_gemmi(
     mtz.datasets[0].dataset_name = dataset_name
 
     # Construct data for Mtz object
-    temp = dataset.reset_index()
+    # GH#255: DataSet is provided using the range_indexed decorator
     columns = []
-    for c in temp.columns:
-        cseries = temp[c]
+    for c in dataset.columns:
+        cseries = dataset[c]
         if isinstance(cseries.dtype, MTZDtype):
             mtz.add_column(label=c, type=cseries.dtype.mtztype)
             columns.append(c)
         # Special case for CENTRIC and PARTIAL flags
         elif cseries.dtype.name == "bool" and c in ["CENTRIC", "PARTIAL"]:
-            temp[c] = temp[c].astype("MTZInt")
+            dataset[c] = dataset[c].astype("MTZInt")
             mtz.add_column(label=c, type="I")
             columns.append(c)
         elif skip_problem_mtztypes:
@@ -152,7 +152,7 @@ def to_gemmi(
                 f"column {c} of type {cseries.dtype} cannot be written to an MTZ file. "
                 f"To skip columns without explicit MTZ dtypes, set skip_problem_mtztypes=True"
             )
-    mtz.set_data(temp[columns].to_numpy(dtype="float32"))
+    mtz.set_data(dataset[columns].to_numpy(dtype="float32"))
 
     # Handle Unmerged data
     if not dataset.merged and not all_in_asu:

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -223,3 +223,16 @@ def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
 
     # Clean up
     temp.close()
+
+
+@pytest.mark.parametrize("range_indexed", [True, False])
+def test_write_mtz_rangeindexed(data_merged, range_indexed):
+    """
+    GH#255: Test DataSet.write_mtz() with pd.RangeIndex index.
+    """
+    if range_indexed:
+        data_merged = data_merged.reset_index()
+
+    with tempfile.NamedTemporaryFile(suffix=".mtz") as temp:
+        data_merged.write_mtz(temp.name)
+        assert exists(temp.name)

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -236,3 +236,19 @@ def test_write_mtz_rangeindexed(data_merged, range_indexed):
     with tempfile.NamedTemporaryFile(suffix=".mtz") as temp:
         data_merged.write_mtz(temp.name)
         assert exists(temp.name)
+
+
+@pytest.mark.parametrize("range_indexed", [True, False])
+def test_to_gemmi_rangeindexed(data_merged, range_indexed):
+    """
+    GH#255: Test DataSet.to_gemmi() with pd.RangeIndex index.
+    """
+    if range_indexed:
+        data_merged = data_merged.reset_index()
+
+    mtz = data_merged.to_gemmi()
+    data_roundtrip = rs.DataSet.from_gemmi(mtz)
+    if range_indexed:
+        data_roundtrip = data_roundtrip.reset_index()
+
+    assert_frame_equal(data_merged, data_roundtrip)

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -226,29 +226,45 @@ def test_write_mtz_names(IOtest_mtz, project_name, crystal_name, dataset_name):
 
 
 @pytest.mark.parametrize("range_indexed", [True, False])
-def test_write_mtz_rangeindexed(data_merged, range_indexed):
+def test_write_mtz_rangeindexed(data_hewl, range_indexed):
     """
     GH#255: Test DataSet.write_mtz() with pd.RangeIndex index.
     """
+    # Add centrics column to test relevant code paths
+    data_hewl.label_centrics(inplace=True)
+
     if range_indexed:
-        data_merged = data_merged.reset_index()
+        data_hewl = data_hewl.reset_index()
+
+    data_before = data_hewl.copy()
 
     with tempfile.NamedTemporaryFile(suffix=".mtz") as temp:
-        data_merged.write_mtz(temp.name)
+        data_hewl.write_mtz(temp.name)
         assert exists(temp.name)
+
+    # Make sure writing MTZ did not alter calling DataSet
+    assert_frame_equal(data_hewl, data_before, check_like=True)
 
 
 @pytest.mark.parametrize("range_indexed", [True, False])
-def test_to_gemmi_rangeindexed(data_merged, range_indexed):
+def test_to_gemmi_rangeindexed(data_hewl, range_indexed):
     """
     GH#255: Test DataSet.to_gemmi() with pd.RangeIndex index.
     """
-    if range_indexed:
-        data_merged = data_merged.reset_index()
+    # Add centrics column to test relevant code paths
+    data_hewl.label_centrics(inplace=True)
 
-    mtz = data_merged.to_gemmi()
+    if range_indexed:
+        data_hewl = data_hewl.reset_index()
+
+    data_before = data_hewl.copy()
+
+    mtz = data_hewl.to_gemmi()
     data_roundtrip = rs.DataSet.from_gemmi(mtz)
     if range_indexed:
         data_roundtrip = data_roundtrip.reset_index()
 
-    assert_frame_equal(data_merged, data_roundtrip)
+    assert_frame_equal(data_hewl, data_roundtrip)
+
+    # Make sure writing MTZ did not alter calling DataSet
+    assert_frame_equal(data_hewl, data_before, check_like=True)


### PR DESCRIPTION
PR fixes #255. 

Currently, DataSet objects with a pd.RangeIndex() (for example, due to a call to `DataSet.reset_index()`) end up causing trouble due to an extra call to `reset_index()` within `rs.io.mtz.to_gemmi()`. To resolve this issue, this PR uses the `range_indexed` decorator to ensure that the relevant functions can assume the calling `DataSet` object is always range indexed. This simplifies the control flow for these functions.

As part of this PR, I also modified `range_indexed` to handle use cases where the decorated function returns None or non-DataSet types.