### PR TITLE
Fix is_isomorphous

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1214,7 +1214,7 @@ class DataSet(pd.DataFrame):
         for param in params:
             param1 = self.cell.__getattribute__(param)
             param2 = other.cell.__getattribute__(param)
-            diff = 200. * np.abs(param1 - param2) / (param1 + param2)
+            diff = 200.0 * np.abs(param1 - param2) / (param1 + param2)
             if diff > cell_threshold:
                 return False
 

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1177,7 +1177,7 @@ class DataSet(pd.DataFrame):
 
         return result
 
-    def is_isomorphous(self, other, cell_threshold=0.05):
+    def is_isomorphous(self, other, cell_threshold=0.5):
         """
         Determine whether DataSet is isomorphous to another DataSet. This
         method confirms isomorphism by ensuring the spacegroups are equivalent,

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1214,7 +1214,8 @@ class DataSet(pd.DataFrame):
         for param in params:
             param1 = self.cell.__getattribute__(param)
             param2 = other.cell.__getattribute__(param)
-            if (np.abs((param1 - param2)) / 100.0) > cell_threshold:
+            diff = 200. * np.abs(param1 - param2) / (param1 + param2)
+            if diff > cell_threshold:
                 return False
 
         return True

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -605,10 +605,10 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
 
 @pytest.mark.parametrize("threshold", [5.0, 1.0, 0.5, 0.1])
 @pytest.mark.parametrize("isomorphous", [True, False])
-@pytest.mark.parametrize("bigger_cell", ['self', 'other']) #Which cell is bigger
+@pytest.mark.parametrize("bigger_cell", ["self", "other"])  # Which cell is bigger
 def test_is_isomorphous_threshold(threshold, isomorphous, bigger_cell):
     """
-    Test that DataSet.is_isorphous(self, other, cell_threshold) method's 
+    Test that DataSet.is_isorphous(self, other, cell_threshold) method's
     cell_threshold operates on percent difference.
     """
     epsilon = 1e-12
@@ -617,18 +617,18 @@ def test_is_isomorphous_threshold(threshold, isomorphous, bigger_cell):
 
     ds = rs.DataSet(cell=cell, spacegroup=spacegroup)
 
-    if bigger_cell == 'self': #other_cell > cell
-        factor = (200. + threshold) / (200. - threshold)
-        if isomorphous: #shrink
-            factor = factor * (1. - epsilon)
-        else: #grow
-            factor = factor * (1. + epsilon)
-    elif bigger_cell == 'other': #other_cell < cell
-        factor = (200. - threshold) / (200. + threshold)
-        if isomorphous: #grow
-            factor = factor * (1. + epsilon)
-        else: #shrink
-            factor = factor * (1. - epsilon)
+    if bigger_cell == "self":  # other_cell > cell
+        factor = (200.0 + threshold) / (200.0 - threshold)
+        if isomorphous:  # shrink
+            factor = factor * (1.0 - epsilon)
+        else:  # grow
+            factor = factor * (1.0 + epsilon)
+    elif bigger_cell == "other":  # other_cell < cell
+        factor = (200.0 - threshold) / (200.0 + threshold)
+        if isomorphous:  # grow
+            factor = factor * (1.0 + epsilon)
+        else:  # shrink
+            factor = factor * (1.0 - epsilon)
 
     other_cell = factor * cell
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -602,6 +602,38 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
         else:
             assert not result
 
+@pytest.mark.parametrize("threshold", [5., 1., 0.5, 0.1])
+@pytest.mark.parametrize("isomorphous", [True, False])
+@pytest.mark.parametrize("sign", [True, False]) #Which cell is bigger
+def test_is_isomorphous_threshold(threshold, isomorphous, sign):
+    """
+    Test that the DataSet.is_isorphous method's cell_threshold operates 
+    on percent difference.
+    """
+    epsilon = 1e-12
+    cell = np.array([34., 45., 98., 90., 90., 90.])
+    spacegroup = 19
+
+    ds = rs.DataSet(cell=cell, spacegroup=spacegroup)
+
+    if sign: #cell_test > cell
+        factor = (200. + threshold) / (200. - threshold)
+        if isomorphous: #shrink
+            factor = factor * (1. - epsilon)
+        else: #grow
+            factor = factor * (1. + epsilon)
+    else: #cell_test < cell
+        factor = (200. - threshold) / (200. + threshold)
+        if isomorphous: #grow
+            factor = factor * (1. + epsilon)
+        else: #shrink
+            factor = factor * (1. - epsilon)
+
+    cell_test = factor * cell
+
+    ds_test = rs.DataSet(cell=cell_test, spacegroup=spacegroup)
+    result = ds.is_isomorphous(ds_test, threshold)
+    assert result == isomorphous
 
 def test_to_gemmi_withNans(data_merged):
     """

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -602,38 +602,40 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
         else:
             assert not result
 
-@pytest.mark.parametrize("threshold", [5., 1., 0.5, 0.1])
+
+@pytest.mark.parametrize("threshold", [5.0, 1.0, 0.5, 0.1])
 @pytest.mark.parametrize("isomorphous", [True, False])
-@pytest.mark.parametrize("sign", [True, False]) #Which cell is bigger
+@pytest.mark.parametrize("sign", [True, False])  # Which cell is bigger
 def test_is_isomorphous_threshold(threshold, isomorphous, sign):
     """
-    Test that the DataSet.is_isorphous method's cell_threshold operates 
+    Test that the DataSet.is_isorphous method's cell_threshold operates
     on percent difference.
     """
     epsilon = 1e-12
-    cell = np.array([34., 45., 98., 90., 90., 90.])
+    cell = np.array([34.0, 45.0, 98.0, 90.0, 90.0, 90.0])
     spacegroup = 19
 
     ds = rs.DataSet(cell=cell, spacegroup=spacegroup)
 
-    if sign: #cell_test > cell
-        factor = (200. + threshold) / (200. - threshold)
-        if isomorphous: #shrink
-            factor = factor * (1. - epsilon)
-        else: #grow
-            factor = factor * (1. + epsilon)
-    else: #cell_test < cell
-        factor = (200. - threshold) / (200. + threshold)
-        if isomorphous: #grow
-            factor = factor * (1. + epsilon)
-        else: #shrink
-            factor = factor * (1. - epsilon)
+    if sign:  # cell_test > cell
+        factor = (200.0 + threshold) / (200.0 - threshold)
+        if isomorphous:  # shrink
+            factor = factor * (1.0 - epsilon)
+        else:  # grow
+            factor = factor * (1.0 + epsilon)
+    else:  # cell_test < cell
+        factor = (200.0 - threshold) / (200.0 + threshold)
+        if isomorphous:  # grow
+            factor = factor * (1.0 + epsilon)
+        else:  # shrink
+            factor = factor * (1.0 - epsilon)
 
     cell_test = factor * cell
 
     ds_test = rs.DataSet(cell=cell_test, spacegroup=spacegroup)
     result = ds.is_isomorphous(ds_test, threshold)
     assert result == isomorphous
+
 
 def test_to_gemmi_withNans(data_merged):
     """

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -614,10 +614,10 @@ def test_is_isomorphous_threshold(threshold):
     spacegroup = 19
 
     ds = rs.DataSet(cell=cell, spacegroup=spacegroup)
-    cell_resize_factor = (200.0 + threshold) / (200. - threshold)
+    cell_resize_factor = (200.0 + threshold) / (200.0 - threshold)
 
     # Make a cell that should be exactly threshold percent bigger
-    other_cell = cell_resize_factor * cell 
+    other_cell = cell_resize_factor * cell
     too_big_cell = other_cell + epsilon
     big_cell = other_cell - epsilon
 
@@ -627,22 +627,23 @@ def test_is_isomorphous_threshold(threshold):
     small_cell = other_cell + epsilon
 
     # Construct data sets
-    too_big = rs.DataSet(cell = too_big_cell, spacegroup = spacegroup)
-    big = rs.DataSet(cell = big_cell, spacegroup = spacegroup)
-    too_small = rs.DataSet(cell = too_small_cell, spacegroup = spacegroup)
-    small = rs.DataSet(cell = small_cell, spacegroup = spacegroup)
+    too_big = rs.DataSet(cell=too_big_cell, spacegroup=spacegroup)
+    big = rs.DataSet(cell=big_cell, spacegroup=spacegroup)
+    too_small = rs.DataSet(cell=too_small_cell, spacegroup=spacegroup)
+    small = rs.DataSet(cell=small_cell, spacegroup=spacegroup)
 
-    #Cell is barely too big to be isomorphous
+    # Cell is barely too big to be isomorphous
     assert not ds.is_isomorphous(too_big, threshold)
 
-    #Cell is barely too small to be isomorphous
+    # Cell is barely too small to be isomorphous
     assert not ds.is_isomorphous(too_small, threshold)
 
-    #Cell is almost too big to be isomorphous
-    assert ds.is_isomorphous(big, threshold) 
+    # Cell is almost too big to be isomorphous
+    assert ds.is_isomorphous(big, threshold)
 
-    #Cell is almost too small to be isomorphous
-    assert ds.is_isomorphous(small, threshold) 
+    # Cell is almost too small to be isomorphous
+    assert ds.is_isomorphous(small, threshold)
+
 
 def test_to_gemmi_withNans(data_merged):
     """

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -605,11 +605,11 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
 
 @pytest.mark.parametrize("threshold", [5.0, 1.0, 0.5, 0.1])
 @pytest.mark.parametrize("isomorphous", [True, False])
-@pytest.mark.parametrize("sign", [True, False])  # Which cell is bigger
-def test_is_isomorphous_threshold(threshold, isomorphous, sign):
+@pytest.mark.parametrize("bigger_cell", ['self', 'other']) #Which cell is bigger
+def test_is_isomorphous_threshold(threshold, isomorphous, bigger_cell):
     """
-    Test that the DataSet.is_isorphous method's cell_threshold operates
-    on percent difference.
+    Test that DataSet.is_isorphous(self, other, cell_threshold) method's 
+    cell_threshold operates on percent difference.
     """
     epsilon = 1e-12
     cell = np.array([34.0, 45.0, 98.0, 90.0, 90.0, 90.0])
@@ -617,23 +617,23 @@ def test_is_isomorphous_threshold(threshold, isomorphous, sign):
 
     ds = rs.DataSet(cell=cell, spacegroup=spacegroup)
 
-    if sign:  # cell_test > cell
-        factor = (200.0 + threshold) / (200.0 - threshold)
-        if isomorphous:  # shrink
-            factor = factor * (1.0 - epsilon)
-        else:  # grow
-            factor = factor * (1.0 + epsilon)
-    else:  # cell_test < cell
-        factor = (200.0 - threshold) / (200.0 + threshold)
-        if isomorphous:  # grow
-            factor = factor * (1.0 + epsilon)
-        else:  # shrink
-            factor = factor * (1.0 - epsilon)
+    if bigger_cell == 'self': #other_cell > cell
+        factor = (200. + threshold) / (200. - threshold)
+        if isomorphous: #shrink
+            factor = factor * (1. - epsilon)
+        else: #grow
+            factor = factor * (1. + epsilon)
+    elif bigger_cell == 'other': #other_cell < cell
+        factor = (200. - threshold) / (200. + threshold)
+        if isomorphous: #grow
+            factor = factor * (1. + epsilon)
+        else: #shrink
+            factor = factor * (1. - epsilon)
 
-    cell_test = factor * cell
+    other_cell = factor * cell
 
-    ds_test = rs.DataSet(cell=cell_test, spacegroup=spacegroup)
-    result = ds.is_isomorphous(ds_test, threshold)
+    other = rs.DataSet(cell=other_cell, spacegroup=spacegroup)
+    result = ds.is_isomorphous(other, threshold)
     assert result == isomorphous
 
 


### PR DESCRIPTION
As discussed in #277 , DataSet.is_isomorphous currently does not do what is indicated in its docstring. This change makes the behavior in line with the expectation that `cell_threshold` is a percent difference. 