### PR TITLE
Deprecated `DataSet.to_reciprocalgrid()` should call `DataSet.to_reciprocal_grid()`

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1585,24 +1585,6 @@ class DataSet(pd.DataFrame):
         warnings.simplefilter("always")
         warnings.warn(message, DeprecationWarning)
 
-        if dmin is not None:
-            ds = self.loc[self.compute_dHKL().dHKL >= dmin, [key]]
-        else:
-            ds = self.loc[:, [key]]
-
-        if gridsize is None:
-            gridsize = self.get_reciprocal_grid_size(dmin=dmin, sample_rate=sample_rate)
-
-        # Set up P1 unit cell
-        p1 = ds.expand_to_p1()
-        p1 = p1.expand_anomalous()
-
-        # Get data and indices
-        data = p1[key].to_numpy()
-        H = p1.get_hkls()
-
-        # Populate grid
-        grid = np.zeros(gridsize, dtype=data.dtype)
-        grid[H[:, 0], H[:, 1], H[:, 2]] = data
-
-        return grid
+        return self.to_reciprocal_grid(
+            key, sample_rate=sample_rate, dmin=dmin, grid_size=gridsize
+        )


### PR DESCRIPTION
This is a very minor bookkeeping PR -- we currently have two function for converting a `DataSet` to a 3D numpy array representing the underlying data: `DataSet.to_reciprocalgrid()` and `DataSet.to_reciprocal_grid()`. The former will be deprecated in favor of the latter, in order to have consistency naming schemes in terms of underscores.

However, we currently have duplicate implementations for both functions. If we want to edit the implementations before we officially remove one of them, we will need to make changes in both places. This PR updates the deprecated code to call the newer version to avoid needing to maintain the code in two places. 