### PR TITLE
add hkls attribute rs.DataSet

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -156,7 +156,7 @@ class DataSet(pd.DataFrame):
         return hkl
 
     def get_hkls(self):
-        """For backwards compatibility retain the get_hkls method in addition to the dataset.hkls attribute"""
+        """Get the Miller indices of the dataset."""
         return self.hkls
 
     @hkls.setter

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -53,7 +53,7 @@ class DataSet(pd.DataFrame):
     centrics : rs.DataSet
         Access only the centric reflections in this dataset
     hkls : ndarray, shape=(n_reflections, 3)
-        Miller indices in DataSet. 
+        Miller indices in DataSet.
     merged : bool
         Whether this is a merged dataset or unmerged
 
@@ -157,27 +157,29 @@ class DataSet(pd.DataFrame):
         return hkl
 
     def get_hkls(self):
-        """ For backwards compatibility retain the get_hkls method in addition to the dataset.hkls attribute """
+        """For backwards compatibility retain the get_hkls method in addition to the dataset.hkls attribute"""
         return self.hkls
 
     @hkls.setter
     @range_indexed
     def hkls(self, hkls):
         if isinstance(hkls, DataSet):
-            """ Convert to numpy if hkls is a dataset """
+            """Convert to numpy if hkls is a dataset"""
             hkls = hkls.hkls
         if isinstance(hkls, np.ndarray):
-            h,k,l = hkls[...,0], hkls[...,1], hkls[...,2]
+            h, k, l = hkls[..., 0], hkls[..., 1], hkls[..., 2]
         else:
-            """ Try coercing to numpy """
+            """Try coercing to numpy"""
             try:
                 hkls = np.array(hkls)
-                h,k,l = hkls[...,0], hkls[...,1], hkls[...,2]
+                h, k, l = hkls[..., 0], hkls[..., 1], hkls[..., 2]
             except:
-                raise ValueError("Unable to convert hkls to a suitable type. Please ensure hkls is a numpy array or rs.DataSet")
-        self['H'] = DataSeries(h, index = self.index, dtype='H')
-        self['K'] = DataSeries(k, index = self.index, dtype='H')
-        self['L'] = DataSeries(l, index = self.index, dtype='H')
+                raise ValueError(
+                    "Unable to convert hkls to a suitable type. Please ensure hkls is a numpy array or rs.DataSet"
+                )
+        self["H"] = DataSeries(h, index=self.index, dtype="H")
+        self["K"] = DataSeries(k, index=self.index, dtype="H")
+        self["L"] = DataSeries(l, index=self.index, dtype="H")
 
     @property
     def centrics(self):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -56,7 +56,6 @@ class DataSet(pd.DataFrame):
         Miller indices in DataSet.
     merged : bool
         Whether this is a merged dataset or unmerged
-
     spacegroup : gemmi.SpaceGroup
         The space group
     reindexing_ops : list

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -43,6 +43,24 @@ class DataSet(pd.DataFrame):
     and attributes, please see the `Pandas.DataFrame documentation`_.
 
     .. _Pandas.DataFrame documentation: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html
+
+    Attributes
+    ----------
+    acentrics : rs.DataSet
+        Access only the acentric reflections in this dataset
+    cell : gemmi.UnitCell
+        The unit cell
+    centrics : rs.DataSet
+        Access only the centric reflections in this dataset
+    hkls : ndarray, shape=(n_reflections, 3)
+        Miller indices in DataSet. 
+    merged : bool
+        Whether this is a merged dataset or unmerged
+
+    spacegroup : gemmi.SpaceGroup
+        The space group
+    reindexing_ops : list
+        Possible reindexing ops consistent with the cell and spacegroup
     """
 
     _metadata = ["_spacegroup", "_cell", "_index_dtypes", "_merged"]
@@ -130,6 +148,36 @@ class DataSet(pd.DataFrame):
     @merged.setter
     def merged(self, val):
         self._merged = val
+
+    @property
+    @range_indexed
+    def hkls(self):
+        """Miller indices"""
+        hkl = self[["H", "K", "L"]].to_numpy(dtype=np.int32)
+        return hkl
+
+    def get_hkls(self):
+        """ For backwards compatibility retain the get_hkls method in addition to the dataset.hkls attribute """
+        return self.hkls
+
+    @hkls.setter
+    @range_indexed
+    def hkls(self, hkls):
+        if isinstance(hkls, DataSet):
+            """ Convert to numpy if hkls is a dataset """
+            hkls = hkls.hkls
+        if isinstance(hkls, np.ndarray):
+            h,k,l = hkls[...,0], hkls[...,1], hkls[...,2]
+        else:
+            """ Try coercing to numpy """
+            try:
+                hkls = np.array(hkls)
+                h,k,l = hkls[...,0], hkls[...,1], hkls[...,2]
+            except:
+                raise ValueError("Unable to convert hkls to a suitable type. Please ensure hkls is a numpy array or rs.DataSet")
+        self['H'] = DataSeries(h, index = self.index, dtype='H')
+        self['K'] = DataSeries(k, index = self.index, dtype='H')
+        self['L'] = DataSeries(l, index = self.index, dtype='H')
 
     @property
     def centrics(self):

--- a/reciprocalspaceship/io/precognition.py
+++ b/reciprocalspaceship/io/precognition.py
@@ -31,7 +31,7 @@ def read_precognition(hklfile, spacegroup=None, cell=None, logfile=None):
         F = pd.read_csv(
             hklfile,
             header=None,
-            delim_whitespace=True,
+            sep="\\s+",
             names=["H", "K", "L", "F(+)", "SigF(+)", "F(-)", "SigF(-)"],
             usecols=usecols,
         )
@@ -49,7 +49,7 @@ def read_precognition(hklfile, spacegroup=None, cell=None, logfile=None):
         F = pd.read_csv(
             hklfile,
             header=None,
-            delim_whitespace=True,
+            sep="\\s+",
             names=[
                 "H",
                 "K",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,33 +8,6 @@ import pytest
 
 import reciprocalspaceship as rs
 
-
-@pytest.fixture
-def hkls():
-    """
-    Return all Miller indices with H, K, L values between [-5, 5]
-    """
-    hmin, hmax = -5, 5
-    H = np.mgrid[hmin : hmax + 1, hmin : hmax + 1, hmin : hmax + 1].reshape((3, -1)).T
-    return H
-
-
-@pytest.fixture
-def dataset_hkl():
-    """
-    Build DataSet for testing containing only Miller indices
-    """
-    hmin, hmax = -5, 5
-    H = (
-        np.mgrid[hmin : hmax + 1 : 2, hmin : hmax + 1 : 2, hmin : hmax + 1 : 2]
-        .reshape((3, -1))
-        .T
-    )
-    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
-    dataset.set_index(["H", "K", "L"], inplace=True)
-    return dataset
-
-
 def load_dataset(datapath, as_gemmi=False):
     """
     Load dataset at given datapath. Datapath is expected to be a list of
@@ -64,6 +37,39 @@ def data_unmerged():
     datapath = ["data", "data_unmerged.mtz"]
     return load_dataset(datapath)
 
+@pytest.fixture
+def hkls(data_merged):
+    """
+    Return all Miller indices with H, K, L values between [-5, 5]
+    """
+    return data_merged.hkls
+
+@pytest.fixture
+def dataset_hkl(data_merged):
+    """
+    Build DataSet for testing containing only Miller indices
+    """
+    H = data_merged.hkls
+    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
+    dataset.set_index(["H", "K", "L"], inplace=True)
+    return dataset
+
+@pytest.fixture
+def hkls_unmerged(data_unmerged):
+    """
+    Return all Miller indices with H, K, L values between [-5, 5]
+    """
+    return data_unmerged.hkls
+
+@pytest.fixture
+def dataset_hkl_unmerged(data_unmerged):
+    """
+    Build DataSet for testing containing only Miller indices
+    """
+    H = data_unmerged.hkls
+    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
+    dataset.set_index(["H", "K", "L"], inplace=True)
+    return dataset
 
 @pytest.fixture(
     params=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 
 import reciprocalspaceship as rs
 
+
 def load_dataset(datapath, as_gemmi=False):
     """
     Load dataset at given datapath. Datapath is expected to be a list of
@@ -37,12 +38,14 @@ def data_unmerged():
     datapath = ["data", "data_unmerged.mtz"]
     return load_dataset(datapath)
 
+
 @pytest.fixture
 def hkls(data_merged):
     """
     Return all Miller indices with H, K, L values between [-5, 5]
     """
     return data_merged.hkls
+
 
 @pytest.fixture
 def dataset_hkl(data_merged):
@@ -54,12 +57,14 @@ def dataset_hkl(data_merged):
     dataset.set_index(["H", "K", "L"], inplace=True)
     return dataset
 
+
 @pytest.fixture
 def hkls_unmerged(data_unmerged):
     """
     Return all Miller indices with H, K, L values between [-5, 5]
     """
     return data_unmerged.hkls
+
 
 @pytest.fixture
 def dataset_hkl_unmerged(data_unmerged):
@@ -70,6 +75,7 @@ def dataset_hkl_unmerged(data_unmerged):
     dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
     dataset.set_index(["H", "K", "L"], inplace=True)
     return dataset
+
 
 @pytest.fixture(
     params=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,32 @@ import pytest
 import reciprocalspaceship as rs
 
 
+@pytest.fixture
+def hkls():
+    """
+    Return all Miller indices with H, K, L values between [-5, 5]
+    """
+    hmin, hmax = -5, 5
+    H = np.mgrid[hmin : hmax + 1, hmin : hmax + 1, hmin : hmax + 1].reshape((3, -1)).T
+    return H
+
+
+@pytest.fixture
+def dataset_hkl():
+    """
+    Build DataSet for testing containing only Miller indices
+    """
+    hmin, hmax = -5, 5
+    H = (
+        np.mgrid[hmin : hmax + 1 : 2, hmin : hmax + 1 : 2, hmin : hmax + 1 : 2]
+        .reshape((3, -1))
+        .T
+    )
+    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
+    dataset.set_index(["H", "K", "L"], inplace=True)
+    return dataset
+
+
 def load_dataset(datapath, as_gemmi=False):
     """
     Load dataset at given datapath. Datapath is expected to be a list of
@@ -37,44 +63,6 @@ def data_unmerged():
     """
     datapath = ["data", "data_unmerged.mtz"]
     return load_dataset(datapath)
-
-
-@pytest.fixture
-def hkls(data_merged):
-    """
-    Return all Miller indices with H, K, L values between [-5, 5]
-    """
-    return data_merged.hkls
-
-
-@pytest.fixture
-def dataset_hkl(data_merged):
-    """
-    Build DataSet for testing containing only Miller indices
-    """
-    H = data_merged.hkls
-    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
-    dataset.set_index(["H", "K", "L"], inplace=True)
-    return dataset
-
-
-@pytest.fixture
-def hkls_unmerged(data_unmerged):
-    """
-    Return all Miller indices with H, K, L values between [-5, 5]
-    """
-    return data_unmerged.hkls
-
-
-@pytest.fixture
-def dataset_hkl_unmerged(data_unmerged):
-    """
-    Build DataSet for testing containing only Miller indices
-    """
-    H = data_unmerged.hkls
-    dataset = rs.DataSet({"H": H[:, 0], "K": H[:, 1], "L": H[:, 2]})
-    dataset.set_index(["H", "K", "L"], inplace=True)
-    return dataset
 
 
 @pytest.fixture(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -714,10 +714,18 @@ def test_select_mtzdtype_ValueError(data_merged, dtype):
 
 
 @pytest.mark.parametrize("merged", [True, False])
-@pytest.mark.parametrize("hkl_type", ['ds', 'index', 'numpy'])
+@pytest.mark.parametrize("hkl_type", ["ds", "index", "numpy"])
 @pytest.mark.parametrize("range_index", [True, False])
 def test_hkls_property_setter(
-    data_merged, data_unmerged, hkls, hkls_unmerged, dataset_hkl, dataset_hkl_unmerged, merged, hkl_type, range_index
+    data_merged,
+    data_unmerged,
+    hkls,
+    hkls_unmerged,
+    dataset_hkl,
+    dataset_hkl_unmerged,
+    merged,
+    hkl_type,
+    range_index,
 ):
     """
     Test the setter for the .hkls property of rs datasets
@@ -729,9 +737,9 @@ def test_hkls_property_setter(
         input_ds = data_unmerged
         hkls = dataset_hkl_unmerged
 
-    if hkl_type == 'ds':
+    if hkl_type == "ds":
         hkls = hkls.reset_index()
-    elif hkl_type == 'numpy':
+    elif hkl_type == "numpy":
         hkls = hkls.hkls
 
     ds = input_ds.copy()
@@ -741,15 +749,15 @@ def test_hkls_property_setter(
     # Confirm we're starting with equivalent miller indices
     expected = ds.hkls
     value = hkls
-    if hkl_type != 'numpy':
+    if hkl_type != "numpy":
         value = value.hkls
     assert np.array_equal(value, expected)
 
     # Shuffle the hkls
-    if hkl_type != 'numpy':
-        hkls = hkls.sample(frac=1.)
+    if hkl_type != "numpy":
+        hkls = hkls.sample(frac=1.0)
     else:
-        np.random.shuffle(hkls) #inplace
+        np.random.shuffle(hkls)  # inplace
 
     # confirm shuffling
     assert not np.array_equal(hkls, ds.hkls)
@@ -758,7 +766,7 @@ def test_hkls_property_setter(
     ds.hkls = hkls
     expected = ds.hkls
     value = hkls
-    if hkl_type != 'numpy':
+    if hkl_type != "numpy":
         value = value.hkls
     assert np.array_equal(value, expected)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -717,30 +717,19 @@ def test_select_mtzdtype_ValueError(data_merged, dtype):
 @pytest.mark.parametrize("hkl_type", ["ds", "index", "numpy"])
 @pytest.mark.parametrize("range_index", [True, False])
 def test_hkls_property_setter(
-    data_merged,
-    data_unmerged,
-    hkls,
-    hkls_unmerged,
-    dataset_hkl,
-    dataset_hkl_unmerged,
-    merged,
-    hkl_type,
-    range_index,
+    data_merged, 
+    data_unmerged, 
+    merged, hkl_type, range_index
 ):
     """
     Test the setter for the .hkls property of rs datasets
     """
     if merged:
         input_ds = data_merged
-        hkls = dataset_hkl
     else:
         input_ds = data_unmerged
-        hkls = dataset_hkl_unmerged
 
-    if hkl_type == "ds":
-        hkls = hkls.reset_index()
-    elif hkl_type == "numpy":
-        hkls = hkls.hkls
+    hkls = input_ds.copy().reset_index()[['H', 'K', 'L']]
 
     ds = input_ds.copy()
     if range_index:
@@ -749,25 +738,22 @@ def test_hkls_property_setter(
     # Confirm we're starting with equivalent miller indices
     expected = ds.hkls
     value = hkls
-    if hkl_type != "numpy":
-        value = value.hkls
-    assert np.array_equal(value, expected)
 
     # Shuffle the hkls
-    if hkl_type != "numpy":
-        hkls = hkls.sample(frac=1.0)
-    else:
-        np.random.shuffle(hkls)  # inplace
+    hkls = hkls.sample(frac=1.)
 
     # confirm shuffling
     assert not np.array_equal(hkls, ds.hkls)
 
     # confirm setter
-    ds.hkls = hkls
+    if hkl_type == 'ds':
+        ds.hkls = hkls
+    elif hkl_type == 'index':
+        ds.hkls = hkls.set_index(['H', 'K', 'L'])
+    elif hkl_type == 'numpy':
+        ds.hkls = hkls.to_numpy()
     expected = ds.hkls
-    value = hkls
-    if hkl_type != "numpy":
-        value = value.hkls
+    value = hkls.hkls
     assert np.array_equal(value, expected)
 
     # Test that all data remained the same

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -717,9 +717,7 @@ def test_select_mtzdtype_ValueError(data_merged, dtype):
 @pytest.mark.parametrize("hkl_type", ["ds", "index", "numpy"])
 @pytest.mark.parametrize("range_index", [True, False])
 def test_hkls_property_setter(
-    data_merged, 
-    data_unmerged, 
-    merged, hkl_type, range_index
+    data_merged, data_unmerged, merged, hkl_type, range_index
 ):
     """
     Test the setter for the .hkls property of rs datasets
@@ -729,7 +727,7 @@ def test_hkls_property_setter(
     else:
         input_ds = data_unmerged
 
-    hkls = input_ds.copy().reset_index()[['H', 'K', 'L']]
+    hkls = input_ds.copy().reset_index()[["H", "K", "L"]]
 
     ds = input_ds.copy()
     if range_index:
@@ -740,17 +738,17 @@ def test_hkls_property_setter(
     value = hkls
 
     # Shuffle the hkls
-    hkls = hkls.sample(frac=1.)
+    hkls = hkls.sample(frac=1.0)
 
     # confirm shuffling
     assert not np.array_equal(hkls, ds.hkls)
 
     # confirm setter
-    if hkl_type == 'ds':
+    if hkl_type == "ds":
         ds.hkls = hkls
-    elif hkl_type == 'index':
-        ds.hkls = hkls.set_index(['H', 'K', 'L'])
-    elif hkl_type == 'numpy':
+    elif hkl_type == "index":
+        ds.hkls = hkls.set_index(["H", "K", "L"])
+    elif hkl_type == "numpy":
         ds.hkls = hkls.to_numpy()
     expected = ds.hkls
     value = hkls.hkls

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -711,3 +711,42 @@ def test_select_mtzdtype_ValueError(data_merged, dtype):
     """
     with pytest.raises(ValueError):
         data_merged.select_mtzdtype(dtype)
+
+
+@pytest.mark.parametrize("merged", [True, False])
+@pytest.mark.parametrize("hkl_as_ds", [True, False])
+@pytest.mark.parametrize("range_index", [True, False])
+def test_hkls_property_setter(data_merged, data_unmerged, merged, hkl_as_ds, range_index):
+    """
+    Test the setter for the .hkls property of rs datasets
+    """
+    if merged:
+        input_ds = data_merged
+    else:
+        input_ds = data_unmerged
+
+    ds = input_ds.copy()
+
+    if range_index:
+        ds = ds.reset_index()
+
+    hmax = 20
+    n = len(ds)
+
+    hkls = np.random.randint(-hmax, hmax+1, size=(n, 3))
+    if hkl_as_ds:
+        hkls = rs.DataSet({
+            'H' : hkls[...,0],
+            'K' : hkls[...,1],
+            'L' : hkls[...,2],
+        })
+            
+    ds.hkls = hkls
+    assert np.array_equal(hkls, ds.hkls)
+
+    # Test that all data remained the same
+    for k in input_ds:
+        if k not in ['H', 'K', 'L']:
+            assert np.array_equal(ds[k], input_ds[k])
+
+

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -716,7 +716,9 @@ def test_select_mtzdtype_ValueError(data_merged, dtype):
 @pytest.mark.parametrize("merged", [True, False])
 @pytest.mark.parametrize("hkl_as_ds", [True, False])
 @pytest.mark.parametrize("range_index", [True, False])
-def test_hkls_property_setter(data_merged, data_unmerged, merged, hkl_as_ds, range_index):
+def test_hkls_property_setter(
+    data_merged, data_unmerged, merged, hkl_as_ds, range_index
+):
     """
     Test the setter for the .hkls property of rs datasets
     """
@@ -733,20 +735,20 @@ def test_hkls_property_setter(data_merged, data_unmerged, merged, hkl_as_ds, ran
     hmax = 20
     n = len(ds)
 
-    hkls = np.random.randint(-hmax, hmax+1, size=(n, 3))
+    hkls = np.random.randint(-hmax, hmax + 1, size=(n, 3))
     if hkl_as_ds:
-        hkls = rs.DataSet({
-            'H' : hkls[...,0],
-            'K' : hkls[...,1],
-            'L' : hkls[...,2],
-        })
-            
+        hkls = rs.DataSet(
+            {
+                "H": hkls[..., 0],
+                "K": hkls[..., 1],
+                "L": hkls[..., 2],
+            }
+        )
+
     ds.hkls = hkls
     assert np.array_equal(hkls, ds.hkls)
 
     # Test that all data remained the same
     for k in input_ds:
-        if k not in ['H', 'K', 'L']:
+        if k not in ["H", "K", "L"]:
             assert np.array_equal(ds[k], input_ds[k])
-
-


### PR DESCRIPTION
This PR makes a `.hkls` attribute for `rs.DataSet` instances. The method has a setter to assign new Miller indices. It retains backward compatibility with the `get_hkls` method. 

The use case here is for being able to set new miller indices using an expression like
```python
ds.hkls = hkls
```
where hkls can either be a dataset containing the keys 'H', 'K', and 'L' or it could be a numpy array. This saves the user having to reset and set the index. 