### PR TITLE
transpose mtz description, add resolution info

### DIFF
--- a/reciprocalspaceship/commandline/mtzdump.py
+++ b/reciprocalspaceship/commandline/mtzdump.py
@@ -79,7 +79,7 @@ def summarize(mtz, precision):
             print(f"Resolution range:  {dHKL.max():.3f} - {dHKL.min():.3f} Å")
         with pd.option_context("display.max_rows", None):
             print(f"\nmtz.head():\n\n{mtz.head()}")
-            print(f"\nmtz.describe():\n\n{mtz.describe().T}")
+            print(f"\nmtz.describe().T:\n\n{mtz.describe().T}")
             print(f"\nmtz.dtypes:\n\n{mtz.dtypes}")
     return
 


### PR DESCRIPTION
Address #289 by transposing the description in `rs.mtzdump`. It also calculates the resolution range of the data if the cell is set. 

The potentially contentious thing about this PR is that it changes the orientation of the description for `rs.mtzdump`. It would be easy to make this dynamic and/or user controlled, but my preference is to make it consistent across inputs. Since the transposed orientation works perfectly fine for any shape of input, I suggest we just use it exclusively. Happy to hear other takes on this. 