### PR TITLE
Fix setuptools dependency issue

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install -e .[doc]
 
     - name: Set up Pandoc
       uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/testdocumentation.yml
+++ b/.github/workflows/testdocumentation.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        pip install -e .[doc]
 
     - name: Set up Pandoc
       uses: r-lib/actions/setup-pandoc@v2

--- a/setup.py
+++ b/setup.py
@@ -80,6 +80,7 @@ setup(
         "scipy",
         "ipython",
         "msgpack",
+        "setuptools",
     ],
     setup_requires=["pytest-runner"],
     tests_require=tests_require,

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,8 @@ setup(
     setup_requires=["pytest-runner"],
     tests_require=tests_require,
     extras_require={
-        "dev": tests_require + docs_require + examples_require,
+        "dev": tests_require,
+        "doc" : docs_require + examples_require
         "examples": examples_require,
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
     tests_require=tests_require,
     extras_require={
         "dev": tests_require,
-        "doc" : docs_require + examples_require
+        "doc" : docs_require + examples_require,
         "examples": examples_require,
     },
     entry_points={


### PR DESCRIPTION
See #297 for details. Setuptools is used to keep track of static versioning in `rs`. We need to have it as an explicit dependency in releases. 