### PR TITLE
Address Pandas warnings raised in CI

### DIFF
--- a/reciprocalspaceship/dtypes/internals.py
+++ b/reciprocalspaceship/dtypes/internals.py
@@ -92,7 +92,7 @@ class BaseMaskedDtype(ExtensionDtype):
     base = None
     type: type
 
-    na_value = libmissing.NA
+    na_value = np.nan
 
     @cache_readonly
     def numpy_dtype(self) -> np.dtype:

--- a/tests/dtypes/test_floats_pandas.py
+++ b/tests/dtypes/test_floats_pandas.py
@@ -222,12 +222,10 @@ class TestMissing(base.BaseMissingTests):
     pass
 
 
-class TestBooleanReduce(base.BaseBooleanReduceTests):
-    pass
-
-
-class TestNumericReduce(base.BaseNumericReduceTests):
-    pass
+class TestReduce(base.BaseReduceTests):
+    def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
+        # Specify if we expect this reduction to succeed.
+        return True
 
 
 class TestParsing(base.BaseParsingTests):

--- a/tests/dtypes/test_ints_pandas.py
+++ b/tests/dtypes/test_ints_pandas.py
@@ -198,11 +198,11 @@ class TestMissing(base.BaseMissingTests):
     pass
 
 
-class TestBooleanReduce(base.BaseBooleanReduceTests):
-    pass
+class TestReduce(base.BaseReduceTests):
+    def _supports_reduction(self, ser: pd.Series, op_name: str) -> bool:
+        # Specify if we expect this reduction to succeed.
+        return True
 
-
-class TestNumericReduce(base.BaseNumericReduceTests):
     def _get_expected_reduction_dtype(self, arr, op_name: str, skipna: bool = False):
         """
         Handle expected return types for reductions that may change int32-backed dtype


### PR DESCRIPTION
This PR makes small changes to the CI and storage of `NaN` values in our ExtensionDtypes to address deprecation warnings. 

There are still two remaining sets of warnings, but these are in tests that are directly inherited from pandas. As such, I'll let these be fixed in the pandas codebase itself, rather than overloading and correcting them:
```

===================================================== warnings summary =====================================================
tests/dtypes/test_floats_pandas.py: 13 warnings
tests/dtypes/test_ints_pandas.py: 4 warnings
site-packages/pandas/tests/extension/base/setitem.py:227: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    arr[idx] = arr[0]

tests/dtypes/test_ints_pandas.py: 4 warnings
tests/dtypes/test_floats_pandas.py: 13 warnings
site-packages/pandas/tests/extension/base/getitem.py:276: FutureWarning: Series.__getitem__ treating keys as positions is deprecated. In a future version, integer keys will always be treated as labels (consistent with DataFrame behavior). To access a value by position, use `ser.iloc[pos]`
    ser[idx]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= tests coverage =================================================
```