### PR TITLE
remove ray, add python 3.14 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         numpy-version: ['numpy<2.0', 'numpy>=2.0']
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+        exclude:
+          - numpy-version: 'numpy<2.0'
+            python-version: '3.14'
 
     # Skip CI if 'skip ci' is contained in latest commit message
     if: "!contains(github.event.head_commit.message, 'skip ci')"

--- a/reciprocalspaceship/algorithms/scale_merged_intensities.py
+++ b/reciprocalspaceship/algorithms/scale_merged_intensities.py
@@ -61,7 +61,6 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     ]
     J = (Jmax - Jmin)[:, None] * grid / 2.0 + (Jmax + Jmin)[:, None] / 2.0
     logJ = np.nan_to_num(np.log(J), -np.inf)
-    logF = 0.5 * logJ.copy()
     log_prefactor = np.log(Jmax - Jmin) - np.log(2.0)
 
     # Log prior (Wilson's prior for intensities)
@@ -87,6 +86,7 @@ def _french_wilson_posterior_quad(Iobs, SigIobs, Sigma, centric, npoints=100):
     )
 
     # Compute expected value and variance of structure factor amplitude
+    logF = 0.5 * logJ
     log_mean_F = log_prefactor + logsumexp(
         logweights + logF + logP + logL - logZ[:, None], axis=1
     )


### PR DESCRIPTION
Since transitioning from Ray to Joblib, we should be able to support python 3.14 now. 