### PR TITLE
loosen `is_isomorphous` threshold

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -1226,7 +1226,7 @@ class DataSet(pd.DataFrame):
 
         return result
 
-    def is_isomorphous(self, other, cell_threshold=0.5):
+    def is_isomorphous(self, other, cell_threshold=5.0):
         """
         Determine whether DataSet is isomorphous to another DataSet. This
         method confirms isomorphism by ensuring the spacegroups are equivalent,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -603,7 +603,7 @@ def test_is_isomorphous(data_unmerged, data_fmodel, sg1, sg2, cell1, cell2):
             assert not result
 
 
-@pytest.mark.parametrize("threshold", [5.0, 1.0, 0.5, 0.1])
+@pytest.mark.parametrize("threshold", [10.0, 5.0, 1.0, 0.5, 0.1])
 def test_is_isomorphous_threshold(threshold):
     """
     Test that DataSet.is_isorphous(self, other, cell_threshold) method's


### PR DESCRIPTION
As elaborated on in #319, this PR would increase the default tolerance for cell comparison in `DataSet.is_isomorphous` from 0.5% to 5%.