### PR TITLE
Update README.md build badge to only use main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 1 / 🚀 = reciprocalspaceship
-![Build](https://github.com/rs-station/reciprocalspaceship/workflows/Build/badge.svg)
+[![Build](https://github.com/rs-station/reciprocalspaceship/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/rs-station/reciprocalspaceship/actions/workflows/build.yml)
 [![Documentation](https://github.com/rs-station/reciprocalspaceship/workflows/Documentation/badge.svg)](https://rs-station.github.io/reciprocalspaceship)
 [![PyPI](https://img.shields.io/pypi/v/reciprocalspaceship?color=blue)](https://pypi.org/project/reciprocalspaceship/)
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/reciprocalspaceship/badges/version.svg)](https://anaconda.org/conda-forge/reciprocalspaceship)


### PR DESCRIPTION
The README.md file reflects the success status of the latest run of the Build GitHub Action. If a PR has a failing build, this can mean that the README looks like the `rs` build is failing even though the main branch is still fine.

This PR updates the status badge to only look at builds of the `main` branch. It also adds a hyperlink to the status badge that links to the build.yaml action. 