### PR TITLE
Wavelength support for mtz files

### DIFF
--- a/reciprocalspaceship/commandline/mtzdump.py
+++ b/reciprocalspaceship/commandline/mtzdump.py
@@ -75,6 +75,8 @@ def summarize(mtz, precision):
                 f"{mtz.cell.alpha:.3f} {mtz.cell.beta:.3f} {mtz.cell.gamma:.3f}"
             )
         )
+        if mtz.wavelength is not None:
+            print(f"Wavelength:  {mtz.wavelength} Å")
         if mtz.cell is not None:
             dHKL = mtz.compute_dHKL().dHKL
             print(f"Resolution range:  {dHKL.max():.3f} - {dHKL.min():.3f} Å")

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -62,7 +62,7 @@ class DataSet(pd.DataFrame):
         Possible reindexing ops consistent with the cell and spacegroup
     """
 
-    _metadata = ["_spacegroup", "_cell", "_index_dtypes", "_merged"]
+    _metadata = ["_spacegroup", "_cell", "_wavelength", "_index_dtypes", "_merged"]
 
     # -------------------------------------------------------------------
     # __init__ method
@@ -76,11 +76,13 @@ class DataSet(pd.DataFrame):
         copy=False,
         spacegroup=None,
         cell=None,
+        wavelength=None,
         merged=None,
     ):
         self._index_dtypes = {}
         self._spacegroup = None
         self._cell = None
+        self._wavelength = None
         self._merged = None
 
         # Construct DataSet from gemmi.Mtz object
@@ -103,6 +105,8 @@ class DataSet(pd.DataFrame):
             self.spacegroup = spacegroup
         if cell is not None:
             self.cell = cell
+        if wavelength is not None:
+            self.wavelength = wavelength
         if merged is not None:
             self.merged = merged
 
@@ -138,6 +142,15 @@ class DataSet(pd.DataFrame):
     @cellify("uc")
     def cell(self, uc):
         self._cell = uc
+
+    @property
+    def wavelength(self):
+        """The wavelength for these data"""
+        return self._wavelength
+
+    @wavelength.setter
+    def wavelength(self, val):
+        self._wavelength = val
 
     @property
     def merged(self):

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -3,6 +3,7 @@ import gemmi
 from reciprocalspaceship import DataSet
 from reciprocalspaceship.dtypes.base import MTZDtype
 from reciprocalspaceship.utils import in_asu
+import warnings
 
 
 def from_gemmi(gemmi_mtz):
@@ -28,7 +29,21 @@ def from_gemmi(gemmi_mtz):
     -------
     rs.DataSet
     """
-    dataset = DataSet(spacegroup=gemmi_mtz.spacegroup, cell=gemmi_mtz.cell)
+    wavelengths = [d.wavelength for d in gemmi_mtz.datasets]
+    num_uniq = len(set(wavelengths))
+    if num_uniq > 1:
+        message = (
+            "Mtz contains multiple datasets with different wavelengths."
+            f"Choosing first wavelength of available {wavelengths}."
+        )
+        warnings.warn(message)
+    wavelength = wavelengths[0]
+
+    dataset = DataSet(
+        spacegroup=gemmi_mtz.spacegroup, 
+        cell=gemmi_mtz.cell, 
+        wavelength=wavelength,
+    )
 
     # Build up DataSet
     for c in gemmi_mtz.columns:
@@ -131,6 +146,13 @@ def to_gemmi(
     mtz.datasets[0].project_name = project_name
     mtz.datasets[0].crystal_name = crystal_name
     mtz.datasets[0].dataset_name = dataset_name
+
+    # In gemmi the default wavelength is 0.0 which obviously means no wavelength
+    # info, but retains float type. 
+    if dataset.wavelength is None:
+        mtz.datasets[0].wavelength = 0.0
+    else:
+        mtz.datasets[0].wavelength = dataset.wavelength
 
     # Construct data for Mtz object
     # GH#255: DataSet is provided using the range_indexed decorator

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -1,9 +1,10 @@
+import warnings
+
 import gemmi
 
 from reciprocalspaceship import DataSet
 from reciprocalspaceship.dtypes.base import MTZDtype
 from reciprocalspaceship.utils import in_asu
-import warnings
 
 
 def from_gemmi(gemmi_mtz):
@@ -40,8 +41,8 @@ def from_gemmi(gemmi_mtz):
     wavelength = wavelengths[0]
 
     dataset = DataSet(
-        spacegroup=gemmi_mtz.spacegroup, 
-        cell=gemmi_mtz.cell, 
+        spacegroup=gemmi_mtz.spacegroup,
+        cell=gemmi_mtz.cell,
         wavelength=wavelength,
     )
 
@@ -148,7 +149,7 @@ def to_gemmi(
     mtz.datasets[0].dataset_name = dataset_name
 
     # In gemmi the default wavelength is 0.0 which obviously means no wavelength
-    # info, but retains float type. 
+    # info, but retains float type.
     if dataset.wavelength is None:
         mtz.datasets[0].wavelength = 0.0
     else:

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -148,7 +148,7 @@ def to_gemmi(
     mtz.datasets[0].crystal_name = crystal_name
     mtz.datasets[0].dataset_name = dataset_name
 
-    # In gemmi the default wavelength is 0.0 which obviously means no wavelength
+    # In gemmi the default wavelength is 0.0 which means no wavelength
     # info, but retains float type.
     if dataset.wavelength is None:
         mtz.datasets[0].wavelength = 0.0

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -13,16 +13,18 @@ def test_constructor_empty():
     assert len(result) == 0
     assert result.spacegroup is None
     assert result.cell is None
+    assert result.wavelength is None
 
 
 @pytest.mark.parametrize("spacegroup", [None, gemmi.SpaceGroup(1), "P 1"])
 @pytest.mark.parametrize(
     "cell", [None, gemmi.UnitCell(1, 1, 1, 90, 90, 90), (1, 1, 1, 90, 90, 90)]
 )
+@pytest.mark.parametrize("wavelength", [None, 1., 2.])
 @pytest.mark.parametrize("merged", [None, True, False])
-def test_constructor_dataset(data_fmodel, spacegroup, cell, merged):
+def test_constructor_dataset(data_fmodel, spacegroup, wavelength, cell, merged):
     """Test DataSet.__init__() when called with a DataSet"""
-    result = rs.DataSet(data_fmodel, spacegroup=spacegroup, cell=cell, merged=merged)
+    result = rs.DataSet(data_fmodel, spacegroup=spacegroup, cell=cell, wavelength=wavelength, merged=merged)
     assert_frame_equal(result, data_fmodel)
 
     if merged is not None:
@@ -46,6 +48,28 @@ def test_constructor_dataset(data_fmodel, spacegroup, cell, merged):
     else:
         assert result.cell == data_fmodel.cell
 
+    if wavelength is not None:
+        assert result.wavelength == wavelength
+    else:
+        assert result.wavelength== data_fmodel.wavelength
+
+@pytest.mark.parametrize(
+    "fixture_name", ['data_fmodel', 'data_hewl']
+)
+def test_read_wavelength(data_fmodel, data_hewl, fixture_name):
+    wavelength_expected = {
+        'data_fmodel' : 1.0,
+        'data_hewl' : 0.0,
+    }
+    ds = locals()[fixture_name]
+    assert wavelength_expected[fixture_name] == ds.wavelength
+
+@pytest.mark.parametrize(
+    "wavelength", [None, 0., 1., 2.]
+)
+def test_set_wavelength(data_fmodel, wavelength):
+    data_fmodel.wavelength = wavelength
+    assert data_fmodel.wavelength == wavelength
 
 @pytest.mark.parametrize(
     "spacegroup", [None, 1, 5, 19, "P 21 21 21", "R 3:h", "R 3:blah", 1.2]

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -20,11 +20,17 @@ def test_constructor_empty():
 @pytest.mark.parametrize(
     "cell", [None, gemmi.UnitCell(1, 1, 1, 90, 90, 90), (1, 1, 1, 90, 90, 90)]
 )
-@pytest.mark.parametrize("wavelength", [None, 1., 2.])
+@pytest.mark.parametrize("wavelength", [None, 1.0, 2.0])
 @pytest.mark.parametrize("merged", [None, True, False])
 def test_constructor_dataset(data_fmodel, spacegroup, wavelength, cell, merged):
     """Test DataSet.__init__() when called with a DataSet"""
-    result = rs.DataSet(data_fmodel, spacegroup=spacegroup, cell=cell, wavelength=wavelength, merged=merged)
+    result = rs.DataSet(
+        data_fmodel,
+        spacegroup=spacegroup,
+        cell=cell,
+        wavelength=wavelength,
+        merged=merged,
+    )
     assert_frame_equal(result, data_fmodel)
 
     if merged is not None:
@@ -51,25 +57,24 @@ def test_constructor_dataset(data_fmodel, spacegroup, wavelength, cell, merged):
     if wavelength is not None:
         assert result.wavelength == wavelength
     else:
-        assert result.wavelength== data_fmodel.wavelength
+        assert result.wavelength == data_fmodel.wavelength
 
-@pytest.mark.parametrize(
-    "fixture_name", ['data_fmodel', 'data_hewl']
-)
+
+@pytest.mark.parametrize("fixture_name", ["data_fmodel", "data_hewl"])
 def test_read_wavelength(data_fmodel, data_hewl, fixture_name):
     wavelength_expected = {
-        'data_fmodel' : 1.0,
-        'data_hewl' : 0.0,
+        "data_fmodel": 1.0,
+        "data_hewl": 0.0,
     }
     ds = locals()[fixture_name]
     assert wavelength_expected[fixture_name] == ds.wavelength
 
-@pytest.mark.parametrize(
-    "wavelength", [None, 0., 1., 2.]
-)
+
+@pytest.mark.parametrize("wavelength", [None, 0.0, 1.0, 2.0])
 def test_set_wavelength(data_fmodel, wavelength):
     data_fmodel.wavelength = wavelength
     assert data_fmodel.wavelength == wavelength
+
 
 @pytest.mark.parametrize(
     "spacegroup", [None, 1, 5, 19, "P 21 21 21", "R 3:h", "R 3:blah", 1.2]

--- a/tests/test_dataset_preserve_attributes.py
+++ b/tests/test_dataset_preserve_attributes.py
@@ -1,12 +1,34 @@
 import gemmi
 import pytest
+import tempfile
 
 import reciprocalspaceship as rs
 
-@pytest.mark.parametrize("check_isomorphous", [True, False])
 @pytest.mark.parametrize("sg", [gemmi.SpaceGroup(19), gemmi.SpaceGroup(96)])
-@pytest.mark.parametrize("wavelength", [0., 1.])
-def test_copy(data_fmodel, check_isomorphous, sg, wavelength):
+@pytest.mark.parametrize("wavelength", [None, 0., 2.])
+def test_roundtrip_write_read(data_fmodel, sg, wavelength):
+    """
+    Test whether attributes of DataSet are preserved through write_mtz
+    followed by read_mtz
+    """
+    with tempfile.NamedTemporaryFile(suffix='.mtz') as temp:
+        mtz_file = temp.name
+        data_fmodel.spacegroup = sg
+        data_fmodel.wavelength = wavelength
+        assert data_fmodel.spacegroup == sg
+        assert data_fmodel.wavelength == wavelength
+
+        data_fmodel.write_mtz(mtz_file)
+        result = rs.read_mtz(mtz_file)
+
+        assert isinstance(result, rs.DataSet)
+        assert len(result) == len(data_fmodel)
+        if wavelength is None:
+            data_fmodel.wavelength = 0.0
+        for attr in data_fmodel._metadata:
+            assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
+
+def test_copy(data_fmodel):
     """
     Test whether attributes of DataSet are preserved through calls to
     pd.copy()

--- a/tests/test_dataset_preserve_attributes.py
+++ b/tests/test_dataset_preserve_attributes.py
@@ -3,6 +3,19 @@ import pytest
 
 import reciprocalspaceship as rs
 
+@pytest.mark.parametrize("check_isomorphous", [True, False])
+@pytest.mark.parametrize("sg", [gemmi.SpaceGroup(19), gemmi.SpaceGroup(96)])
+@pytest.mark.parametrize("wavelength", [0., 1.])
+def test_copy(data_fmodel, check_isomorphous, sg, wavelength):
+    """
+    Test whether attributes of DataSet are preserved through calls to
+    pd.copy()
+    """
+    result = data_fmodel.copy(deep=True)
+    assert isinstance(result, rs.DataSet)
+    assert len(result) == len(data_fmodel)
+    for attr in data_fmodel._metadata:
+        assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
 
 @pytest.mark.parametrize("check_isomorphous", [True, False])
 @pytest.mark.parametrize("sg", [gemmi.SpaceGroup(19), gemmi.SpaceGroup(96)])

--- a/tests/test_dataset_preserve_attributes.py
+++ b/tests/test_dataset_preserve_attributes.py
@@ -1,17 +1,19 @@
+import tempfile
+
 import gemmi
 import pytest
-import tempfile
 
 import reciprocalspaceship as rs
 
+
 @pytest.mark.parametrize("sg", [gemmi.SpaceGroup(19), gemmi.SpaceGroup(96)])
-@pytest.mark.parametrize("wavelength", [None, 0., 2.])
+@pytest.mark.parametrize("wavelength", [None, 0.0, 2.0])
 def test_roundtrip_write_read(data_fmodel, sg, wavelength):
     """
     Test whether attributes of DataSet are preserved through write_mtz
     followed by read_mtz
     """
-    with tempfile.NamedTemporaryFile(suffix='.mtz') as temp:
+    with tempfile.NamedTemporaryFile(suffix=".mtz") as temp:
         mtz_file = temp.name
         data_fmodel.spacegroup = sg
         data_fmodel.wavelength = wavelength
@@ -28,6 +30,7 @@ def test_roundtrip_write_read(data_fmodel, sg, wavelength):
         for attr in data_fmodel._metadata:
             assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
 
+
 def test_copy(data_fmodel):
     """
     Test whether attributes of DataSet are preserved through calls to
@@ -38,6 +41,7 @@ def test_copy(data_fmodel):
     assert len(result) == len(data_fmodel)
     for attr in data_fmodel._metadata:
         assert result.__getattr__(attr) == data_fmodel.__getattr__(attr)
+
 
 @pytest.mark.parametrize("check_isomorphous", [True, False])
 @pytest.mark.parametrize("sg", [gemmi.SpaceGroup(19), gemmi.SpaceGroup(96)])


### PR DESCRIPTION
This is a proposal for supporting wavelength in mtz files. It 
 - Adds a wavelength attribute to rs.DataSet and
 - Reads / writes wavelength to mtz files in the io submodule

One downside to this approach is that the mtz file spec actually supports multiple datasets with, potentially, different wavelengths. `rs.from_gemmi` aggregates the info from multiple datasets and stores them in separate columns. From that point, any information about how the columns were structured in the input mtz is lost. 