### PR TITLE
add batching for mtz files

### DIFF
--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -663,6 +663,8 @@ class DataSet(pd.DataFrame):
         project_name="reciprocalspaceship",
         crystal_name="reciprocalspaceship",
         dataset_name="reciprocalspaceship",
+        batch=True,
+        batch_key=None,
     ):
         """
         Write DataSet to MTZ file.
@@ -687,6 +689,10 @@ class DataSet(pd.DataFrame):
             Crystal name to assign to MTZ file
         dataset_name : str
             Dataset name to assign to MTZ file
+        batch : bool (optional)
+            Optionally record batches in the MTZ header for unmerged data
+        batch_key : str (optional)
+            Override the BATCH column selection. Required if multiple batch columns are present. 
         """
         from reciprocalspaceship import io
 
@@ -697,6 +703,8 @@ class DataSet(pd.DataFrame):
             project_name,
             crystal_name,
             dataset_name,
+            batch,
+            batch_key,
         )
 
     def select_mtzdtype(self, dtype):

--- a/reciprocalspaceship/dataset.py
+++ b/reciprocalspaceship/dataset.py
@@ -692,7 +692,7 @@ class DataSet(pd.DataFrame):
         batch : bool (optional)
             Optionally record batches in the MTZ header for unmerged data
         batch_key : str (optional)
-            Override the BATCH column selection. Required if multiple batch columns are present. 
+            Override the BATCH column selection. Required if multiple batch columns are present.
         """
         from reciprocalspaceship import io
 

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -71,6 +71,23 @@ def from_gemmi(gemmi_mtz):
 
     return dataset
 
+def _select_batch_key(dataset, batch_key):
+    # Locate available batch columns
+    available = dataset.dtypes[dataset.dtypes == 'B'].keys()
+    if batch_key is not None:
+        if batch_key in available:
+            return batch_key
+        else:
+            raise ValueError(f"batch_key, {batch_key}, not in available batch columns, {available}")
+    else:
+        if len(available) == 0:
+            return None # No batching
+        elif len(available) == 1:
+            return available[0] # Only option
+        else:
+            raise ValueError(
+                f"Multiple batch columns. Set batch_key to one of: {available}"
+            )
 
 def to_gemmi(
     dataset,
@@ -78,6 +95,8 @@ def to_gemmi(
     project_name,
     crystal_name,
     dataset_name,
+    batch=True,
+    batch_key=None,
 ):
     """
     Construct gemmi.Mtz object from DataSet
@@ -102,6 +121,10 @@ def to_gemmi(
         Crystal name to assign to MTZ file
     dataset_name : str
         Dataset name to assign to MTZ file
+    batch : bool (optional)
+        Optionally record batches in the MTZ header for unmerged data
+    batch_key : str(optional)
+        Override the BATCH column selection. Required if multiple batch columns are present. 
 
     Returns
     -------
@@ -138,9 +161,24 @@ def to_gemmi(
 
     # Handle Unmerged data
     if not dataset.merged:
+        if batch:
+            batch_key = _select_batch_key(dataset, batch_key)
+            if batch_key is not None:
+                all_batch_nums = sorted(dataset[batch_key].unique())
+                for batch_num in all_batch_nums:
+                    batch = gemmi.Mtz.Batch()
+                    batch.number = batch_num
+                    batch.cell = mtz.cell
+                    batch.dataset_id = 0 
+                    mtz.batches.append(batch)
+        elif batch_key is not None:
+            raise ValueError(f"batched output is disabled, but batck_key is set to {batch_key}")
+
         all_in_asu = in_asu(dataset.get_hkls(), dataset.spacegroup).all()
         if not all_in_asu:
             dataset.hkl_to_asu(inplace=True)
+    elif batch_key is not None:
+            raise ValueError(f"dataset is merged, but user requested batch_key: {batch_key}")
 
     # Add Dataset with indicated names
     mtz.add_dataset("reciprocalspaceship")
@@ -217,6 +255,8 @@ def write_mtz(
     project_name,
     crystal_name,
     dataset_name,
+    batch=True,
+    batch_key=None,
 ):
     """
     Write an MTZ reflection file from the reflection data in a DataSet.
@@ -243,9 +283,13 @@ def write_mtz(
         Crystal name to assign to MTZ file
     dataset_name : str
         Dataset name to assign to MTZ file
+    batch : bool (optional)
+        Optionally record batches in the MTZ header for unmerged data
+    batch_key : str (optional)
+        Override the BATCH column selection. Required if multiple batch columns are present. 
     """
     mtz = to_gemmi(
-        dataset, skip_problem_mtztypes, project_name, crystal_name, dataset_name
+        dataset, skip_problem_mtztypes, project_name, crystal_name, dataset_name, batch, batch_key,
     )
     mtz.write_to_file(mtzfile)
     return

--- a/reciprocalspaceship/io/mtz.py
+++ b/reciprocalspaceship/io/mtz.py
@@ -71,23 +71,27 @@ def from_gemmi(gemmi_mtz):
 
     return dataset
 
+
 def _select_batch_key(dataset, batch_key):
     # Locate available batch columns
-    available = dataset.dtypes[dataset.dtypes == 'B'].keys()
+    available = dataset.dtypes[dataset.dtypes == "B"].keys()
     if batch_key is not None:
         if batch_key in available:
             return batch_key
         else:
-            raise ValueError(f"batch_key, {batch_key}, not in available batch columns, {available}")
+            raise ValueError(
+                f"batch_key, {batch_key}, not in available batch columns, {available}"
+            )
     else:
         if len(available) == 0:
-            return None # No batching
+            return None  # No batching
         elif len(available) == 1:
-            return available[0] # Only option
+            return available[0]  # Only option
         else:
             raise ValueError(
                 f"Multiple batch columns. Set batch_key to one of: {available}"
             )
+
 
 def to_gemmi(
     dataset,
@@ -124,7 +128,7 @@ def to_gemmi(
     batch : bool (optional)
         Optionally record batches in the MTZ header for unmerged data
     batch_key : str(optional)
-        Override the BATCH column selection. Required if multiple batch columns are present. 
+        Override the BATCH column selection. Required if multiple batch columns are present.
 
     Returns
     -------
@@ -169,16 +173,20 @@ def to_gemmi(
                     batch = gemmi.Mtz.Batch()
                     batch.number = batch_num
                     batch.cell = mtz.cell
-                    batch.dataset_id = 0 
+                    batch.dataset_id = 0
                     mtz.batches.append(batch)
         elif batch_key is not None:
-            raise ValueError(f"batched output is disabled, but batck_key is set to {batch_key}")
+            raise ValueError(
+                f"batched output is disabled, but batck_key is set to {batch_key}"
+            )
 
         all_in_asu = in_asu(dataset.get_hkls(), dataset.spacegroup).all()
         if not all_in_asu:
             dataset.hkl_to_asu(inplace=True)
     elif batch_key is not None:
-            raise ValueError(f"dataset is merged, but user requested batch_key: {batch_key}")
+        raise ValueError(
+            f"dataset is merged, but user requested batch_key: {batch_key}"
+        )
 
     # Add Dataset with indicated names
     mtz.add_dataset("reciprocalspaceship")
@@ -286,10 +294,16 @@ def write_mtz(
     batch : bool (optional)
         Optionally record batches in the MTZ header for unmerged data
     batch_key : str (optional)
-        Override the BATCH column selection. Required if multiple batch columns are present. 
+        Override the BATCH column selection. Required if multiple batch columns are present.
     """
     mtz = to_gemmi(
-        dataset, skip_problem_mtztypes, project_name, crystal_name, dataset_name, batch, batch_key,
+        dataset,
+        skip_problem_mtztypes,
+        project_name,
+        crystal_name,
+        dataset_name,
+        batch,
+        batch_key,
     )
     mtz.write_to_file(mtzfile)
     return

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -3,10 +3,10 @@ import tempfile
 from os.path import exists
 
 import gemmi
+import numpy as np
 import pytest
 from pandas.testing import assert_frame_equal
 
-import numpy as np
 import reciprocalspaceship as rs
 from reciprocalspaceship.utils import in_asu
 
@@ -133,8 +133,9 @@ def test_roundtrip_unmerged(data_unmerged, label_centrics):
     temp.close()
     temp2.close()
 
-@pytest.mark.parametrize('batch', [True, False])
-@pytest.mark.parametrize('batch_key', [None, 'BATCH', 'MISSING'])
+
+@pytest.mark.parametrize("batch", [True, False])
+@pytest.mark.parametrize("batch_key", [None, "BATCH", "MISSING"])
 def test_write_unmerged_batches(data_unmerged, batch, batch_key):
     batch_key = "BATCH"
     f = tempfile.NamedTemporaryFile(suffix=".mtz")
@@ -157,6 +158,7 @@ def test_write_unmerged_batches(data_unmerged, batch, batch_key):
         else:
             expected_batches = []
         assert np.array_equal(test_batches, expected_batches)
+
 
 @pytest.mark.parametrize("in_asu", [True, False])
 def test_unmerged_after_write(data_unmerged, in_asu):

--- a/tests/io/test_mtz.py
+++ b/tests/io/test_mtz.py
@@ -6,6 +6,7 @@ import gemmi
 import pytest
 from pandas.testing import assert_frame_equal
 
+import numpy as np
 import reciprocalspaceship as rs
 from reciprocalspaceship.utils import in_asu
 
@@ -132,6 +133,30 @@ def test_roundtrip_unmerged(data_unmerged, label_centrics):
     temp.close()
     temp2.close()
 
+@pytest.mark.parametrize('batch', [True, False])
+@pytest.mark.parametrize('batch_key', [None, 'BATCH', 'MISSING'])
+def test_write_unmerged_batches(data_unmerged, batch, batch_key):
+    batch_key = "BATCH"
+    f = tempfile.NamedTemporaryFile(suffix=".mtz")
+    if not batch and batch_key is not None:
+        raises = True
+    elif batch_key not in data_unmerged:
+        raises = True
+    else:
+        raises = False
+
+    if raises:
+        with pytest.raises(ValueError):
+            data_unmerged.write_mtz(f.name, batch=batch, batch_key=batch_key)
+    else:
+        data_unmerged.write_mtz(f.name, batch=batch, batch_key=batch_key)
+        gemmi_mtz = gemmi.read_mtz_file(f.name)
+        test_batches = [b.number for b in gemmi_mtz.batches]
+        if batch:
+            expected_batches = sorted(data_unmerged[batch_key].unique())
+        else:
+            expected_batches = []
+        assert np.array_equal(test_batches, expected_batches)
 
 @pytest.mark.parametrize("in_asu", [True, False])
 def test_unmerged_after_write(data_unmerged, in_asu):


### PR DESCRIPTION
This attempts to address #344 to enable batching with `dataset.write_mtz`. I could use some eyes on this control flow. 

This changes the signature for `rs.DataSet.write_mtz` adding `batch=True` and `batch_key=None` options. `write_mtz` will generate a naive set of batches in the header if `batch` is truthy. `batch_key` will be inferred and is only explicitly needed of there are multiple columns with BATCH dtype. `batch=False` and `batch_key is not None` will raise a ValueError. 